### PR TITLE
nvme: Do a clean NVMe shutdown

### DIFF
--- a/arch/arm/dts/t8103-j274.dts
+++ b/arch/arm/dts/t8103-j274.dts
@@ -57,20 +57,16 @@
 };
 
 &i2c1 {
-	clock-frequency = <50000>;
-
 	speaker_amp: codec@31 {
 		compatible = "ti,tas5770l", "ti,tas2770";
 		reg = <0x31>;
 		reset-gpios = <&pinctrl_ap 181 GPIO_ACTIVE_HIGH>;
 		#sound-dai-cells = <0>;
-	};
+	};	
 };
 
 &i2c2 {
 	status = "okay";
-
-	clock-frequency = <50000>;
 
 	jack_codec: codec@48 {
 		compatible = "cirrus,cs42l83", "cirrus,cs42l42";
@@ -93,7 +89,6 @@
 		simple-audio-card,dai-link@0 {
 			reg = <0>;
 			format = "left_j";
-			tdm-slot-width = <32>;
 			mclk-fs = <64>;
 
 			link0_cpu: cpu {
@@ -108,12 +103,11 @@
 		};
 
 		simple-audio-card,dai-link@1 {
+			reg = <1>;
 			bitclock-inversion;
 			frame-inversion;
-			reg = <1>;
 			format = "i2s";
 			mclk-fs = <64>;
-			tdm-slot-width = <32>;
 
 			link1_cpu: cpu {
 				sound-dai = <&mca 2>;

--- a/arch/arm/dts/t8103-j293.dts
+++ b/arch/arm/dts/t8103-j293.dts
@@ -70,7 +70,6 @@
 
 &i2c2 {
 	status = "okay";
-	clock-frequency = <50000>;
 
 	jack_codec: codec@48 {
 		compatible = "cirrus,cs42l83", "cirrus,cs42l42";

--- a/arch/arm/dts/t8103-j313.dts
+++ b/arch/arm/dts/t8103-j313.dts
@@ -69,8 +69,6 @@
 /delete-node/ &port02;
 
 &i2c3 {
-	clock-frequency = <50000>;
-
 	jack_codec: codec@48 {
 		compatible = "cirrus,cs42l83", "cirrus,cs42l42";
 		reg = <0x48>;

--- a/arch/arm/dts/t8103-j456.dts
+++ b/arch/arm/dts/t8103-j456.dts
@@ -75,8 +75,6 @@
 };
 
 &i2c1 {
-	clock-frequency = <50000>;
-
 	jack_codec: codec@48 {
 		compatible = "cirrus,cs42l83", "cirrus,cs42l42";
 		reg = <0x48>;

--- a/arch/arm/dts/t8103-j457.dts
+++ b/arch/arm/dts/t8103-j457.dts
@@ -63,8 +63,6 @@
 /delete-node/ &port01;
 
 &i2c1 {
-	clock-frequency = <50000>;
-
 	jack_codec: codec@48 {
 		compatible = "cirrus,cs42l83", "cirrus,cs42l42";
 		reg = <0x48>;

--- a/arch/arm/dts/t8103-jxxx.dtsi
+++ b/arch/arm/dts/t8103-jxxx.dtsi
@@ -9,8 +9,6 @@
  * Copyright The Asahi Linux Contributors
  */
 
-#include <dt-bindings/spmi/spmi.h>
-
 / {
 	aliases {
 		serial0 = &serial0;
@@ -123,21 +121,12 @@
  */
 &port00 {
 	bus-range = <1 1>;
-	pwren-gpios = <&smc 13 0>;
+	pwren-gpios = <&smc_gpio 13 GPIO_ACTIVE_HIGH>;
 	wifi0: network@0,0 {
 		compatible = "pci14e4,4425";
 		reg = <0x10000 0x0 0x0 0x0 0x0>;
 		/* To be filled by the loader */
 		local-mac-address = [00 00 00 00 00 00];
 		apple,antenna-sku = "XX";
-	};
-};
-
-&spmi {
-	status = "okay";
-
-	pmu@f {
-		compatible = "apple,sera-pmu";
-		reg = <0xf SPMI_USID>;
 	};
 };

--- a/arch/arm/dts/t8103.dtsi
+++ b/arch/arm/dts/t8103.dtsi
@@ -11,6 +11,8 @@
 #include <dt-bindings/interrupt-controller/apple-aic.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/pinctrl/apple.h>
+#include <dt-bindings/spmi/spmi.h>
+#include <dt-bindings/gpio/gpio.h>
 
 / {
 	compatible = "apple,t8103", "apple,arm-platform";
@@ -22,68 +24,236 @@
 		#address-cells = <2>;
 		#size-cells = <0>;
 
-		cpu0: cpu@0 {
+		cpu-map {
+			cluster0 {
+				core0 {
+					cpu = <&cpu_e0>;
+				};
+				core1 {
+					cpu = <&cpu_e1>;
+				};
+				core2 {
+					cpu = <&cpu_e2>;
+				};
+				core3 {
+					cpu = <&cpu_e3>;
+				};
+			};
+
+			cluster1 {
+				core0 {
+					cpu = <&cpu_p0>;
+				};
+				core1 {
+					cpu = <&cpu_p1>;
+				};
+				core2 {
+					cpu = <&cpu_p2>;
+				};
+				core3 {
+					cpu = <&cpu_p3>;
+				};
+			};
+		};
+
+		cpu_e0: cpu@0 {
 			compatible = "apple,icestorm";
 			device_type = "cpu";
 			reg = <0x0 0x0>;
 			enable-method = "spin-table";
 			cpu-release-addr = <0 0>; /* To be filled by loader */
+			operating-points-v2 = <&ecluster_opp>;
+			capacity-dmips-mhz = <714>;
+			apple,freq-domain = <&cpufreq_hw 0>;
 		};
 
-		cpu1: cpu@1 {
+		cpu_e1: cpu@1 {
 			compatible = "apple,icestorm";
 			device_type = "cpu";
 			reg = <0x0 0x1>;
 			enable-method = "spin-table";
 			cpu-release-addr = <0 0>; /* To be filled by loader */
+			operating-points-v2 = <&ecluster_opp>;
+			capacity-dmips-mhz = <714>;
+			apple,freq-domain = <&cpufreq_hw 0>;
 		};
 
-		cpu2: cpu@2 {
+		cpu_e2: cpu@2 {
 			compatible = "apple,icestorm";
 			device_type = "cpu";
 			reg = <0x0 0x2>;
 			enable-method = "spin-table";
 			cpu-release-addr = <0 0>; /* To be filled by loader */
+			operating-points-v2 = <&ecluster_opp>;
+			capacity-dmips-mhz = <714>;
+			apple,freq-domain = <&cpufreq_hw 0>;
 		};
 
-		cpu3: cpu@3 {
+		cpu_e3: cpu@3 {
 			compatible = "apple,icestorm";
 			device_type = "cpu";
 			reg = <0x0 0x3>;
 			enable-method = "spin-table";
 			cpu-release-addr = <0 0>; /* To be filled by loader */
+			operating-points-v2 = <&ecluster_opp>;
+			capacity-dmips-mhz = <714>;
+			apple,freq-domain = <&cpufreq_hw 0>;
 		};
 
-		cpu4: cpu@10100 {
+		cpu_p0: cpu@10100 {
 			compatible = "apple,firestorm";
 			device_type = "cpu";
 			reg = <0x0 0x10100>;
 			enable-method = "spin-table";
 			cpu-release-addr = <0 0>; /* To be filled by loader */
+			operating-points-v2 = <&pcluster_opp>;
+			capacity-dmips-mhz = <1024>;
+			apple,freq-domain = <&cpufreq_hw 1>;
 		};
 
-		cpu5: cpu@10101 {
+		cpu_p1: cpu@10101 {
 			compatible = "apple,firestorm";
 			device_type = "cpu";
 			reg = <0x0 0x10101>;
 			enable-method = "spin-table";
 			cpu-release-addr = <0 0>; /* To be filled by loader */
+			operating-points-v2 = <&pcluster_opp>;
+			capacity-dmips-mhz = <1024>;
+			apple,freq-domain = <&cpufreq_hw 1>;
 		};
 
-		cpu6: cpu@10102 {
+		cpu_p2: cpu@10102 {
 			compatible = "apple,firestorm";
 			device_type = "cpu";
 			reg = <0x0 0x10102>;
 			enable-method = "spin-table";
 			cpu-release-addr = <0 0>; /* To be filled by loader */
+			operating-points-v2 = <&pcluster_opp>;
+			capacity-dmips-mhz = <1024>;
+			apple,freq-domain = <&cpufreq_hw 1>;
 		};
 
-		cpu7: cpu@10103 {
+		cpu_p3: cpu@10103 {
 			compatible = "apple,firestorm";
 			device_type = "cpu";
 			reg = <0x0 0x10103>;
 			enable-method = "spin-table";
 			cpu-release-addr = <0 0>; /* To be filled by loader */
+			operating-points-v2 = <&pcluster_opp>;
+			capacity-dmips-mhz = <1024>;
+			apple,freq-domain = <&cpufreq_hw 1>;
+		};
+	};
+
+	ecluster_opp: opp-table-0 {
+		compatible = "operating-points-v2";
+		opp-shared;
+
+		opp01 {
+			opp-hz = /bits/ 64 <600000000>;
+			opp-level = <1>;
+			clock-latency-ns = <7500>;
+		};
+		opp02 {
+			opp-hz = /bits/ 64 <972000000>;
+			opp-level = <2>;
+			clock-latency-ns = <22000>;
+		};
+		opp03 {
+			opp-hz = /bits/ 64 <1332000000>;
+			opp-level = <3>;
+			clock-latency-ns = <27000>;
+		};
+		opp04 {
+			opp-hz = /bits/ 64 <1704000000>;
+			opp-level = <4>;
+			clock-latency-ns = <33000>;
+		};
+		opp05 {
+			opp-hz = /bits/ 64 <2064000000>;
+			opp-level = <5>;
+			clock-latency-ns = <50000>;
+		};
+	};
+
+	pcluster_opp: opp-table-1 {
+		compatible = "operating-points-v2";
+		opp-shared;
+
+		opp01 {
+			opp-hz = /bits/ 64 <600000000>;
+			opp-level = <1>;
+			clock-latency-ns = <8000>;
+		};
+		opp02 {
+			opp-hz = /bits/ 64 <828000000>;
+			opp-level = <2>;
+			clock-latency-ns = <19000>;
+		};
+		opp03 {
+			opp-hz = /bits/ 64 <1056000000>;
+			opp-level = <3>;
+			clock-latency-ns = <21000>;
+		};
+		opp04 {
+			opp-hz = /bits/ 64 <1284000000>;
+			opp-level = <4>;
+			clock-latency-ns = <23000>;
+		};
+		opp05 {
+			opp-hz = /bits/ 64 <1500000000>;
+			opp-level = <5>;
+			clock-latency-ns = <24000>;
+		};
+		opp06 {
+			opp-hz = /bits/ 64 <1728000000>;
+			opp-level = <6>;
+			clock-latency-ns = <29000>;
+		};
+		opp07 {
+			opp-hz = /bits/ 64 <1956000000>;
+			opp-level = <7>;
+			clock-latency-ns = <31000>;
+		};
+		opp08 {
+			opp-hz = /bits/ 64 <2184000000>;
+			opp-level = <8>;
+			clock-latency-ns = <34000>;
+		};
+		opp09 {
+			opp-hz = /bits/ 64 <2388000000>;
+			opp-level = <9>;
+			clock-latency-ns = <36000>;
+		};
+		opp10 {
+			opp-hz = /bits/ 64 <2592000000>;
+			opp-level = <10>;
+			clock-latency-ns = <51000>;
+		};
+		opp11 {
+			opp-hz = /bits/ 64 <2772000000>;
+			opp-level = <11>;
+			clock-latency-ns = <54000>;
+		};
+		opp12 {
+			opp-hz = /bits/ 64 <2988000000>;
+			opp-level = <12>;
+			clock-latency-ns = <55000>;
+		};
+		opp13 {
+			opp-hz = /bits/ 64 <3096000000>;
+			opp-level = <13>;
+			clock-latency-ns = <55000>;
+		};
+		opp14 {
+			opp-hz = /bits/ 64 <3144000000>;
+			opp-level = <14>;
+			clock-latency-ns = <56000>;
+		};
+		opp15 {
+			opp-hz = /bits/ 64 <3204000000>;
+			opp-level = <15>;
+			clock-latency-ns = <56000>;
 		};
 	};
 
@@ -118,6 +288,29 @@
 
 		ranges;
 		nonposted-mmio;
+
+		clk_ecluster: clock-controller@210e20000 {
+			compatible = "apple,t8103-cluster-clk", "apple,cluster-clk";
+			#clock-cells = <0>;
+			reg = <0x2 0x10e20000 0x0 0x4000>;
+			operating-points-v2 = <&ecluster_opp>;
+		};
+
+		clk_pcluster: clock-controller@211e20000 {
+			compatible = "apple,t8103-cluster-clk", "apple,cluster-clk";
+			#clock-cells = <0>;
+			reg = <0x2 0x11e20000 0x0 0x4000>;
+			operating-points-v2 = <&pcluster_opp>;
+		};
+
+		cpufreq_hw: cpufreq@210e00000 {
+			compatible = "apple,t8103-cluster-cpufreq", "apple,cluster-cpufreq";
+			reg = <0x2 0x10e20000 0 0x1000>,
+				<0x2 0x11e20000 0 0x1000>;
+			reg-names = "cluster0", "cluster1";
+
+			#freq-domain-cells = <1>;
+		};
 
 		i2c0: i2c@235010000 {
 			compatible = "apple,t8103-i2c", "apple,i2c";
@@ -155,8 +348,8 @@
 			pinctrl-names = "default";
 			#address-cells = <0x1>;
 			#size-cells = <0x0>;
-			power-domains = <&ps_i2c2>;
 			status = "disabled"; /* not used in all devices */
+			power-domains = <&ps_i2c2>;
 		};
 
 		i2c3: i2c@23501c000 {
@@ -303,14 +496,79 @@
 			};
 		};
 
-		spmi: spmi@23d0d9300 {
+		nub_spmi: spmi@23d0d9300 {
 			compatible = "apple,t8103-spmi", "apple,spmi";
 			reg = <0x2 0x3d0d9300 0x0 0x100>;
-			interrupt-parent = <&aic>;
-			interrupts = <AIC_IRQ 343 IRQ_TYPE_LEVEL_HIGH>;
 			#address-cells = <2>;
 			#size-cells = <0>;
-			status = "disabled";
+
+			pmu1: pmu@f {
+				compatible = "apple,sera-pmu", "apple,spmi-pmu";
+				reg = <0xf SPMI_USID>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				rtc_nvmem@d000 {
+					compatible = "apple,spmi-pmu-nvmem";
+					reg = <0xd000 0x300>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					pm_setting: pm-setting@1 {
+						reg = <0x1 0x1>;
+					};
+
+					rtc_offset: rtc-offset@100 {
+						reg = <0x100 0x6>;
+					};
+				};
+
+				legacy_nvmem@9f00 {
+					compatible = "apple,spmi-pmu-nvmem";
+					reg = <0x9f00 0x20>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					boot_stage: boot-stage@1 {
+						reg = <0x1 0x1>;
+					};
+
+					boot_error_count: boot-error-count@2 {
+						reg = <0x2 0x1>;
+						bits = <0 4>;
+					};
+
+					panic_count: panic-count@2 {
+						reg = <0x2 0x1>;
+						bits = <4 4>;
+					};
+
+					boot_error_stage: boot-error-stage@3 {
+						reg = <0x3 0x1>;
+					};
+
+					shutdown_flag: shutdown-flag@f {
+						reg = <0xf 0x1>;
+						bits = <3 1>;
+					};
+				};
+
+				scrpad_nvmem@a000 {
+					compatible = "apple,spmi-pmu-nvmem";
+					reg = <0xa000 0x1000>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					fault_shadow: fault-shadow@67b {
+						reg = <0x67b 0x10>;
+					};
+
+					socd: socd@b00 {
+						reg = <0xb00 0x400>;
+					};
+				};
+
+			};
 		};
 
 		pinctrl_nub: pinctrl@23d1f0000 {
@@ -350,6 +608,44 @@
 			interrupts = <AIC_IRQ 338 IRQ_TYPE_LEVEL_HIGH>;
 		};
 
+		smc_mbox: mbox@23e408000 {
+			compatible = "apple,t8103-asc-mailbox", "apple,asc-mailbox-v4";
+			reg = <0x2 0x3e408000 0x0 0x4000>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 400 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 401 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 402 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 403 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names = "send-empty", "send-not-empty",
+				"recv-empty", "recv-not-empty";
+			#mbox-cells = <0>;
+		};
+
+		smc: smc@23e400000 {
+			compatible = "apple,t8103-smc", "apple,smc";
+			reg = <0x2 0x3e400000 0x0 0x4000>,
+				<0x2 0x3fe00000 0x0 0x100000>;
+			reg-names = "smc", "sram";
+			mboxes = <&smc_mbox>;
+
+			smc_gpio: gpio {
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
+
+			smc_rtc: rtc {
+				nvmem-cells = <&rtc_offset>;
+				nvmem-cell-names = "rtc_offset";
+			};
+
+			smc_reboot: reboot {
+				nvmem-cells = <&shutdown_flag>, <&boot_stage>,
+					<&boot_error_count>, <&panic_count>, <&pm_setting>;
+				nvmem-cell-names = "shutdown_flag", "boot_stage",
+					"boot_error_count", "panic_count", "pm_setting";
+			};
+		};
+
 		pinctrl_smc: pinctrl@23e820000 {
 			compatible = "apple,t8103-pinctrl", "apple,pinctrl";
 			reg = <0x2 0x3e820000 0x0 0x4000>;
@@ -369,28 +665,6 @@
 				     <AIC_IRQ 395 IRQ_TYPE_LEVEL_HIGH>,
 				     <AIC_IRQ 396 IRQ_TYPE_LEVEL_HIGH>,
 				     <AIC_IRQ 397 IRQ_TYPE_LEVEL_HIGH>;
-		};
-
-		smc_mbox: mbox@23e408000 {
-			compatible = "apple,t8103-asc-mailbox", "apple,asc-mailbox-v4";
-			reg = <0x2 0x3e408000 0x0 0x4000>;
-			interrupt-parent = <&aic>;
-			interrupts = <AIC_IRQ 400 IRQ_TYPE_LEVEL_HIGH>,
-				     <AIC_IRQ 401 IRQ_TYPE_LEVEL_HIGH>,
-				     <AIC_IRQ 402 IRQ_TYPE_LEVEL_HIGH>,
-				     <AIC_IRQ 403 IRQ_TYPE_LEVEL_HIGH>;
-			interrupt-names = "send-empty", "send-not-empty",
-					  "recv-empty", "recv-not-empty";
-			#mbox-cells = <0>;
-		};
-
-		smc: smc@23e050000 {
-			compatible = "apple,smc";
-			reg = <0x2 0x3e050000 0x0 0x4000>;
-			mboxes = <&smc_mbox>;
-			gpio-controller;
-			#gpio-cells = <2>;
-			gpio-13 = <0x00800000>;
 		};
 
 		pinctrl_aop: pinctrl@24a820000 {
@@ -452,6 +726,7 @@
 			reg = <0x3 0x82280000 0x0 0x100000>;
 			interrupt-parent = <&aic>;
 			interrupts = <AIC_IRQ 777 IRQ_TYPE_LEVEL_HIGH>;
+			dr_mode = "otg";
 			usb-role-switch;
 			role-switch-default-mode = "host";
 			iommus = <&dwc3_0_dart_0 0>, <&dwc3_0_dart_1 1>;
@@ -481,6 +756,7 @@
 			reg = <0x5 0x02280000 0x0 0x100000>;
 			interrupt-parent = <&aic>;
 			interrupts = <AIC_IRQ 857 IRQ_TYPE_LEVEL_HIGH>;
+			dr_mode = "otg";
 			usb-role-switch;
 			role-switch-default-mode = "host";
 			iommus = <&dwc3_1_dart_0 0>, <&dwc3_1_dart_1 1>;
@@ -655,7 +931,7 @@
 		admac: dma-controller@238200000 {
 			compatible = "apple,t8103-admac", "apple,admac";
 			reg = <0x2 0x38200000 0x0 0x34000>;
-			dma-channels = <12>;
+			dma-channels = <24>;
 			interrupt-parent = <&aic>;
 			interrupts = <AIC_IRQ 626 IRQ_TYPE_LEVEL_HIGH>;
 			#dma-cells = <1>;
@@ -667,28 +943,35 @@
 			compatible = "apple,t8103-mca", "apple,mca";
 			reg = <0x2 0x38400000 0x0 0x18000>,
 				<0x2 0x38300000 0x0 0x30000>;
+
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 619 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 620 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 621 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 622 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 623 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 624 IRQ_TYPE_LEVEL_HIGH>;
+
 			reg-names = "clusters", "switch";
-			clocks = <&nco 0>, <&nco 1>, <&nco 2>, <&nco 3>;
-			power-domains = <&ps_mca0>; //, <&ps_mca1>, <&ps_mca2>, <&ps_mca3>, <&ps_mca4>, <&ps_mca5>;
-			resets = <&ps_mca0>, <&ps_mca1>, <&ps_mca2>, <&ps_mca3>, <&ps_mca4>, <&ps_mca5>;
+			clocks = <&nco 0>, <&nco 1>, <&nco 2>,
+					<&nco 3>, <&nco 4>, <&nco 4>;
+			power-domains = <&ps_mca0>;
+
+			dmas = <&admac 0>, <&admac 1>, <&admac 2>, <&admac 3>,
+				<&admac 4>, <&admac 5>, <&admac 6>, <&admac 7>,
+				<&admac 8>, <&admac 9>, <&admac 10>, <&admac 11>,
+				<&admac 12>, <&admac 13>, <&admac 14>, <&admac 15>,
+				<&admac 16>, <&admac 17>, <&admac 18>, <&admac 19>,
+				<&admac 20>, <&admac 21>, <&admac 22>, <&admac 23>;
+			dma-names = "tx0a", "rx0a", "tx0b", "rx0b",
+				"tx1a", "rx1a", "tx1b", "rx1b", 
+				"tx2a", "rx2a", "tx2b", "rx2b", 
+				"tx3a", "rx3a", "tx3b", "rx3b", 
+				"tx4a", "rx4a", "tx4b", "rx4b", 
+				"tx5a", "rx5a", "tx5b", "rx5b";
 
 			#sound-dai-cells = <1>;
 			apple,nclusters = <6>;
-			apple,mclk-range = <2600000 25000000>;
-
-			route {
-				dmas = <&admac 2>;
-				dma-names = "tx";
-				apple,serdes = <1>;
-				sound-dai = <&mca 0>;
-			};
-
-			route2 {
-				dmas = <&admac 6>;
-				dma-names = "tx";
-				apple,serdes = <3>;
-				sound-dai = <&mca 2>;
-			};
 		};
 	};
 };

--- a/drivers/nvme/nvme.c
+++ b/drivers/nvme/nvme.c
@@ -27,9 +27,8 @@
 #define IO_TIMEOUT		30
 #define MAX_PRP_POOL		512
 
-static int nvme_wait_ready(struct nvme_dev *dev, bool enabled)
+static int nvme_wait_csts(struct nvme_dev *dev, u32 mask, u32 val)
 {
-	u32 bit = enabled ? NVME_CSTS_RDY : 0;
 	int timeout;
 	ulong start;
 
@@ -38,7 +37,7 @@ static int nvme_wait_ready(struct nvme_dev *dev, bool enabled)
 
 	start = get_timer(0);
 	while (get_timer(start) < timeout) {
-		if ((readl(&dev->bar->csts) & NVME_CSTS_RDY) == bit)
+		if ((readl(&dev->bar->csts) & mask) == val)
 			return 0;
 	}
 
@@ -295,7 +294,7 @@ static int nvme_enable_ctrl(struct nvme_dev *dev)
 	dev->ctrl_config |= NVME_CC_ENABLE;
 	writel(dev->ctrl_config, &dev->bar->cc);
 
-	return nvme_wait_ready(dev, true);
+	return nvme_wait_csts(dev, NVME_CSTS_RDY, NVME_CSTS_RDY);
 }
 
 static int nvme_disable_ctrl(struct nvme_dev *dev)
@@ -304,7 +303,16 @@ static int nvme_disable_ctrl(struct nvme_dev *dev)
 	dev->ctrl_config &= ~NVME_CC_ENABLE;
 	writel(dev->ctrl_config, &dev->bar->cc);
 
-	return nvme_wait_ready(dev, false);
+	return nvme_wait_csts(dev, NVME_CSTS_RDY, 0);
+}
+
+static int nvme_shutdown_ctrl(struct nvme_dev *dev)
+{
+	dev->ctrl_config &= ~NVME_CC_SHN_MASK;
+	dev->ctrl_config |= NVME_CC_SHN_NORMAL;
+	writel(dev->ctrl_config, &dev->bar->cc);
+
+	return nvme_wait_csts(dev, NVME_CSTS_SHST_MASK, NVME_CSTS_SHST_CMPLT);
 }
 
 static void nvme_free_queue(struct nvme_queue *nvmeq)
@@ -900,6 +908,13 @@ free_nvme:
 int nvme_shutdown(struct udevice *udev)
 {
 	struct nvme_dev *ndev = dev_get_priv(udev);
+	int ret;
+
+	ret = nvme_shutdown_ctrl(ndev);
+	if (ret < 0) {
+		printf("Error: %s: Shutdown timed out!\n", udev->name);
+		return ret;
+	}
 
 	return nvme_disable_ctrl(ndev);
 }

--- a/drivers/usb/common/common.c
+++ b/drivers/usb/common/common.c
@@ -40,6 +40,22 @@ enum usb_dr_mode usb_get_dr_mode(ofnode node)
 	return USB_DR_MODE_UNKNOWN;
 }
 
+enum usb_dr_mode usb_get_role_switch_default_mode(ofnode node)
+{
+	const char *dr_mode;
+	int i;
+
+	dr_mode = ofnode_read_string(node, "role-switch-default-mode");
+	if (!dr_mode)
+		return USB_DR_MODE_UNKNOWN;
+
+	for (i = 0; i < ARRAY_SIZE(usb_dr_modes); i++)
+		if (!strcmp(dr_mode, usb_dr_modes[i]))
+			return i;
+
+	return USB_DR_MODE_UNKNOWN;
+}
+
 static const char *const speed_names[] = {
 	[USB_SPEED_UNKNOWN] = "UNKNOWN",
 	[USB_SPEED_LOW] = "low-speed",

--- a/drivers/usb/host/xhci-dwc3.c
+++ b/drivers/usb/host/xhci-dwc3.c
@@ -209,6 +209,12 @@ static int xhci_dwc3_probe(struct udevice *dev)
 	writel(reg, &dwc3_reg->g_usb2phycfg[0]);
 
 	dr_mode = usb_get_dr_mode(dev_ofnode(dev));
+	if (dr_mode == USB_DR_MODE_OTG &&
+	    dev_read_bool(dev, "usb-role-switch")) {
+		dr_mode = usb_get_role_switch_default_mode(dev_ofnode(dev));
+		if (dr_mode == USB_DR_MODE_UNKNOWN)
+			dr_mode = USB_DR_MODE_OTG;
+	}
 	if (dr_mode == USB_DR_MODE_UNKNOWN)
 		/* by default set dual role mode to HOST */
 		dr_mode = USB_DR_MODE_HOST;

--- a/include/linux/usb/otg.h
+++ b/include/linux/usb/otg.h
@@ -28,6 +28,16 @@ enum usb_dr_mode {
 enum usb_dr_mode usb_get_dr_mode(ofnode node);
 
 /**
+ * usb_get_dr_mode() - Get dual role mode for given device
+ * @node: ofnode of the given device
+ *
+ * The function gets phy interface string from property
+ * 'role-switch-defaulr-mode', and returns the correspondig enum
+ * usb_dr_mode
+ */
+enum usb_dr_mode usb_get_role_switch_default_mode(ofnode node);
+
+/**
  * usb_get_maximum_speed() - Get maximum speed for given device
  * @node: ofnode of the given device
  *


### PR DESCRIPTION
The brute-force controller disable method can end up racing controller
initilization and causing a crash when we shut down Apple ANS2 NVMe
controllers. Do a proper controlled shutdown, which does block until
things are quiesced properly.

Signed-off-by: Hector Martin <marcan@marcan.st>