### PR TITLE
arm: apple: nvme: Reset device in probe()

### DIFF
--- a/drivers/nvme/nvme_apple.c
+++ b/drivers/nvme/nvme_apple.c
@@ -206,6 +206,9 @@ static int apple_nvme_probe(struct udevice *dev)
 	if (ret < 0)
 		return ret;
 
+	reset_assert_bulk(&priv->resets);
+	reset_deassert_bulk(&priv->resets);
+
 	ret = mbox_get_by_index(dev, 0, &priv->chan);
 	if (ret < 0)
 		return ret;


### PR DESCRIPTION
Required on the Apple M2 when the NVMe was used by m1n1 to load the
next stage.

Signed-off-by: Janne Grunau <j@jannau.net>
