### PR TITLE
arm: apple: rtkit: wait up to 30 seconds for IOP power ack

### DIFF
--- a/arch/arm/mach-apple/rtkit.c
+++ b/arch/arm/mach-apple/rtkit.c
@@ -409,7 +409,9 @@ wait_epmap:
 	rtk->ap_pwr = APPLE_RTKIT_PWR_STATE_QUIESCED;
 
 	while (rtk->iop_pwr != APPLE_RTKIT_PWR_STATE_ON) {
-		ret = apple_rtkit_poll(rtk, TIMEOUT_1SEC_US);
+		ret = apple_rtkit_poll(rtk, 30 * TIMEOUT_1SEC_US);
+		if (ret == -ETIMEDOUT)
+			printf("%s: timed out whiole waiting on IOP_POWER state ack\n", __func__);
 		if (ret < 0)
 			return ret;
 	}


### PR DESCRIPTION
Fixes NVMe initialization on 8TB SSD devices. Tested on a 8TB M2 Ultra Mac Studio.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
