### PR TITLE
Update device trees to match 6.18 kernel, to fix issues with USB on M1 series.

### DIFF
--- a/arch/arm/dts/hwmon-common.dtsi
+++ b/arch/arm/dts/hwmon-common.dtsi
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0+ OR MIT
+/*
+ * hwmon sensors expected on all systems
+ *
+ * Copyright The Asahi Linux Contributors
+ */
+
+&smc_hwmon {
+	power-PSTR {
+		apple,key-id = "PSTR";
+		label = "Total System Power";
+	};
+	power-PDTR {
+		apple,key-id = "PDTR";
+		label = "AC Input Power";
+	};
+	power-PMVR {
+		apple,key-id = "PMVR";
+		label = "3.8 V Rail Power";
+	};
+	temperature-TH0x {
+		apple,key-id = "TH0x";
+		label = "NAND Flash Temperature";
+	};
+	voltage-VD0R {
+		apple,key-id = "VD0R";
+		label = "AC Input Voltage";
+	};
+	current-ID0R {
+		apple,key-id = "ID0R";
+		label = "AC Input Current";
+	};
+};

--- a/arch/arm/dts/hwmon-fan-dual.dtsi
+++ b/arch/arm/dts/hwmon-fan-dual.dtsi
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0+ OR MIT
+/*
+ * Copyright The Asahi Linux Contributors
+ *
+ * Fan hwmon sensors for machines with 2 fan.
+ */
+
+#include "hwmon-fan.dtsi"
+
+&smc_hwmon {
+	fan-F0Ac {
+		label = "Fan 1";
+	};
+	fan-F1Ac {
+		apple,key-id = "F1Ac";
+		label = "Fan 2";
+		apple,fan-minimum = "F1Mn";
+		apple,fan-maximum = "F1Mx";
+		apple,fan-target = "F1Tg";
+		apple,fan-mode = "F1Md";
+	};
+};

--- a/arch/arm/dts/hwmon-fan.dtsi
+++ b/arch/arm/dts/hwmon-fan.dtsi
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0+ OR MIT
+/*
+ * Copyright The Asahi Linux Contributors
+ *
+ * Fan hwmon sensors for machines with a single fan.
+ */
+
+&smc_hwmon {
+	fan-F0Ac {
+		apple,key-id = "F0Ac";
+		label = "Fan";
+		apple,fan-minimum = "F0Mn";
+		apple,fan-maximum = "F0Mx";
+		apple,fan-target = "F0Tg";
+		apple,fan-mode = "F0Md";
+	};
+};

--- a/arch/arm/dts/hwmon-laptop.dtsi
+++ b/arch/arm/dts/hwmon-laptop.dtsi
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0+ OR MIT
+/*
+ * hwmon sensors expected on all laptops
+ *
+ * Copyright The Asahi Linux Contributors
+ */
+
+&smc_hwmon {
+	power-PHPC {
+		apple,key-id = "PHPC";
+		label = "Heatpipe Power";
+	};
+	temperature-TB0T {
+		apple,key-id = "TB0T";
+		label = "Battery Hotspot";
+	};
+	temperature-TCHP {
+		apple,key-id = "TCHP";
+		label = "Charge Regulator Temp";
+	};
+	temperature-TW0P {
+		apple,key-id = "TW0P";
+		label = "WiFi/BT Module Temp";
+	};
+	voltage-SBAV {
+		apple,key-id = "SBAV";
+		label = "Battery Voltage";
+	};
+	voltage-VD0R {
+		apple,key-id = "VD0R";
+		label = "Charger Input Voltage";
+	};
+};

--- a/arch/arm/dts/hwmon-mini.dtsi
+++ b/arch/arm/dts/hwmon-mini.dtsi
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0+ OR MIT
+/*
+ * hwmon sensors common to the Mac mini desktop
+ * models, but not the Studio or Pro.
+ *
+ * Copyright The Asahi Linux Contributors
+ */
+
+#include "hwmon-fan.dtsi"
+
+&smc_hwmon {
+	temperature-TW0P {
+		apple,key-id = "TW0P";
+		label = "WiFi/BT Module Temp";
+	};
+};

--- a/arch/arm/dts/spi1-nvram.dtsi
+++ b/arch/arm/dts/spi1-nvram.dtsi
@@ -1,10 +1,17 @@
 // SPDX-License-Identifier: GPL-2.0+ OR MIT
-/*
- * Common config for Apple's nvram using a SPI nor flash. This is common on all
- * M1 and M2 devices.  identically set up identically on all M1 and M2 devicesspi1, spinor and nvram config identical on all devices
- *
- * Copyright The Asahi Linux Contributors
- */
+//
+// Devicetree include for common spi-nor nvram flash.
+//
+// Apple uses a consistent configiguration for the nvram on all known M1* and
+// M2* devices.
+//
+// Copyright The Asahi Linux Contributors
+
+/ {
+	aliases {
+		nvram = &nvram;
+	};
+};
 
 &spi1 {
 	status = "okay";
@@ -13,8 +20,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0x0>;
 		spi-max-frequency = <25000000>;
-		#address-cells = <1>;
-		#size-cells = <1>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/arch/arm/dts/t6000-j314s.dts
+++ b/arch/arm/dts/t6000-j314s.dts
@@ -32,6 +32,11 @@
 	adj-height-mm = <189>;
 };
 
+&aop_audio {
+	apple,chassis-name = "J314";
+	apple,machine-kind = "MacBook Pro";
+};
+
 &sound {
 	compatible = "apple,j314-macaudio", "apple,macaudio";
 	model = "MacBook Pro J314";

--- a/arch/arm/dts/t6000-j316s.dts
+++ b/arch/arm/dts/t6000-j316s.dts
@@ -32,6 +32,11 @@
 	adj-height-mm = <216>;
 };
 
+&aop_audio {
+	apple,chassis-name = "J316";
+	apple,machine-kind = "MacBook Pro";
+};
+
 &sound {
 	compatible = "apple,j316-macaudio", "apple,macaudio";
 	model = "MacBook Pro J316";

--- a/arch/arm/dts/t6001-j314c.dts
+++ b/arch/arm/dts/t6001-j314c.dts
@@ -32,6 +32,11 @@
 	adj-height-mm = <189>;
 };
 
+&aop_audio {
+	apple,chassis-name = "J314";
+	apple,machine-kind = "MacBook Pro";
+};
+
 &sound {
 	compatible = "apple,j314-macaudio", "apple,macaudio";
 	model = "MacBook Pro J314";

--- a/arch/arm/dts/t6001-j316c.dts
+++ b/arch/arm/dts/t6001-j316c.dts
@@ -32,6 +32,11 @@
 	adj-height-mm = <216>;
 };
 
+&aop_audio {
+	apple,chassis-name = "J316";
+	apple,machine-kind = "MacBook Pro";
+};
+
 &sound {
 	compatible = "apple,j316-macaudio", "apple,macaudio";
 	model = "MacBook Pro J316";

--- a/arch/arm/dts/t6001-j375c.dts
+++ b/arch/arm/dts/t6001-j375c.dts
@@ -17,6 +17,18 @@
 	model = "Apple Mac Studio (M1 Max, 2022)";
 };
 
+&wifi0 {
+	brcm,board-type = "apple,okinawa";
+};
+
+&bluetooth0 {
+	brcm,board-type = "apple,okinawa";
+};
+
+&dpaudio0 {
+	status = "okay";
+};
+
 &sound {
 	compatible = "apple,j375-macaudio", "apple,macaudio";
 	model = "Mac Studio J375";
@@ -37,3 +49,14 @@
 		line-name = "usb-hub-rst";
 	};
 };
+
+&gpu {
+	apple,avg-power-ki-only = <0.6375>;
+	apple,avg-power-kp = <0.58>;
+	apple,avg-power-target-filter-tc = <1>;
+	apple,perf-base-pstate = <3>;
+	apple,ppm-ki = <5.8>;
+	apple,ppm-kp = <0.355>;
+};
+
+#include "hwmon-fan-dual.dtsi"

--- a/arch/arm/dts/t6001.dtsi
+++ b/arch/arm/dts/t6001.dtsi
@@ -25,24 +25,6 @@
 / {
 	compatible = "apple,t6001", "apple,arm-platform";
 
-	reserved-memory {
-		#address-cells = <2>;
-		#size-cells = <2>;
-		ranges;
-
-		uat_handoff: uat-handoff {
-			reg = <0 0 0 0>;
-		};
-
-		uat_pagetables: uat-pagetables {
-			reg = <0 0 0 0>;
-		};
-
-		uat_ttbs: uat-ttbs {
-			reg = <0 0 0 0>;
-		};
-	};
-
 	soc {
 		compatible = "simple-bus";
 		#address-cells = <2>;
@@ -89,5 +71,5 @@
 };
 
 &gpu {
-	compatible = "apple,agx-t6001", "apple,agx-g13x";
+	compatible = "apple,agx-t6001", "apple,agx-g13c", "apple,agx-g13s";
 };

--- a/arch/arm/dts/t6002-j375d.dts
+++ b/arch/arm/dts/t6002-j375d.dts
@@ -21,6 +21,10 @@
 	};
 };
 
+&dpaudio0 {
+	status = "okay";
+};
+
 &sound {
 	compatible = "apple,j375-macaudio", "apple,macaudio";
 	model = "Mac Studio J375";
@@ -47,14 +51,14 @@
 				#size-cells = <0>;
 				port@0 {
 					reg = <0>;
-					typec4_con_hs: endpoint {
-						remote-endpoint = <&typec4_usb_hs>;
+					typec4_connector_hs: endpoint {
+						remote-endpoint = <&dwc3_4_hs>;
 					};
 				};
 				port@1 {
 					reg = <1>;
-					typec4_con_ss: endpoint {
-						remote-endpoint = <&typec4_usb_ss>;
+					typec4_connector_ss: endpoint {
+						remote-endpoint = <&atcphy4_typec_lanes>;
 					};
 				};
 			};
@@ -80,14 +84,14 @@
 				#size-cells = <0>;
 				port@0 {
 					reg = <0>;
-					typec5_con_hs: endpoint {
-						remote-endpoint = <&typec5_usb_hs>;
+					typec5_connector_hs: endpoint {
+						remote-endpoint = <&dwc3_5_hs>;
 					};
 				};
 				port@1 {
 					reg = <1>;
-					typec5_con_ss: endpoint {
-						remote-endpoint = <&typec5_usb_ss>;
+					typec5_connector_ss: endpoint {
+						remote-endpoint = <&atcphy5_typec_lanes>;
 					};
 				};
 			};
@@ -95,36 +99,96 @@
 	};
 };
 
+&wifi0 {
+	brcm,board-type = "apple,okinawa";
+};
+
+&bluetooth0 {
+	brcm,board-type = "apple,okinawa";
+};
+
 /* USB controllers on die 1 */
 &dwc3_0_die1 {
-	port {
-		typec4_usb_hs: endpoint {
-			remote-endpoint = <&typec4_con_hs>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			dwc3_4_hs: endpoint {
+				remote-endpoint = <&typec4_connector_hs>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			dwc3_4_ss: endpoint {
+				remote-endpoint = <&atcphy4_usb3>;
+			};
 		};
 	};
 };
 
 &dwc3_1_die1 {
-	port {
-		typec5_usb_hs: endpoint {
-			remote-endpoint = <&typec5_con_hs>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			dwc3_5_hs: endpoint {
+				remote-endpoint = <&typec5_connector_hs>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			dwc3_5_ss: endpoint {
+				remote-endpoint = <&atcphy5_usb3>;
+			};
 		};
 	};
 };
 
 /* Type-C PHYs */
 &atcphy0_die1 {
-	port {
-		typec4_usb_ss: endpoint {
-			remote-endpoint = <&typec4_con_ss>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			atcphy4_typec_lanes: endpoint {
+				remote-endpoint = <&typec4_connector_ss>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			atcphy4_usb3: endpoint {
+				remote-endpoint = <&dwc3_4_ss>;
+			};
 		};
 	};
 };
 
 &atcphy1_die1 {
-	port {
-		typec5_usb_ss: endpoint {
-			remote-endpoint = <&typec5_con_ss>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			atcphy5_typec_lanes: endpoint {
+				remote-endpoint = <&typec5_connector_ss>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			atcphy5_usb3: endpoint {
+				remote-endpoint = <&dwc3_5_ss>;
+			};
 		};
 	};
 };
@@ -143,7 +207,6 @@
 /delete-node/ &atcphy3_die1;
 /delete-node/ &atcphy3_xbar_die1;
 
-
 /* delete unused always-on power-domains on die 1 */
 
 /delete-node/ &ps_atc2_usb_aon_die1;
@@ -154,3 +217,14 @@
 
 /delete-node/ &ps_disp0_cpu0_die1;
 /delete-node/ &ps_disp0_fe_die1;
+
+&gpu {
+	apple,avg-power-ki-only = <0.6375>;
+	apple,avg-power-kp = <0.58>;
+	apple,avg-power-target-filter-tc = <1>;
+	apple,perf-base-pstate = <3>;
+	apple,ppm-ki = <5.8>;
+	apple,ppm-kp = <0.355>;
+};
+
+#include "hwmon-fan-dual.dtsi"

--- a/arch/arm/dts/t6002.dtsi
+++ b/arch/arm/dts/t6002.dtsi
@@ -321,5 +321,5 @@
 };
 
 &gpu {
-	compatible = "apple,agx-t6002", "apple,agx-g13x";
+	compatible = "apple,agx-t6002", "apple,agx-g13d", "apple,agx-g13s";
 };

--- a/arch/arm/dts/t600x-common.dtsi
+++ b/arch/arm/dts/t600x-common.dtsi
@@ -460,7 +460,7 @@
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
 		clock-frequency = <0>;
-		clock-output-names = "clk_dispext0";
+		clock-output-names = "clk_dispext1";
 	};
 
 	clk_dispext1_die1: clock-dispext1_die1 {
@@ -484,19 +484,28 @@
 		#size-cells = <2>;
 		ranges;
 
+		gpu_globals: globals {
+			status = "disabled";
+		};
+
+		gpu_hw_cal_a: hw-cal-a {
+			status = "disabled";
+		};
+
+		gpu_hw_cal_b: hw-cal-b {
+			status = "disabled";
+		};
+
 		uat_handoff: uat-handoff {
 			reg = <0 0 0 0>;
-			no-map;
 		};
 
 		uat_pagetables: uat-pagetables {
 			reg = <0 0 0 0>;
-			no-map;
 		};
 
 		uat_ttbs: uat-ttbs {
 			reg = <0 0 0 0>;
-			no-map;
 		};
 	};
 };

--- a/arch/arm/dts/t600x-die0.dtsi
+++ b/arch/arm/dts/t600x-die0.dtsi
@@ -40,6 +40,38 @@
 		#apple,bw-scratch-cells = <3>;
 	};
 
+	smc: smc@290400000 {
+		compatible = "apple,t6000-smc", "apple,smc";
+		reg = <0x2 0x90400000 0x0 0x4000>,
+			<0x2 0x91e00000 0x0 0x100000>;
+		reg-names = "smc", "sram";
+		mboxes = <&smc_mbox>;
+
+		smc_gpio: gpio {
+			compatible = "apple,smc-gpio";
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		smc_hwmon: hwmon {
+			compatible = "apple,smc-hwmon";
+		};
+
+		smc_rtc: rtc {
+			compatible = "apple,smc-rtc";
+			nvmem-cells = <&rtc_offset>;
+			nvmem-cell-names = "rtc_offset";
+		};
+
+		smc_reboot: reboot {
+			compatible = "apple,smc-reboot";
+			nvmem-cells = <&shutdown_flag>, <&boot_stage>,
+				<&boot_error_count>, <&panic_count>, <&pm_setting>;
+			nvmem-cell-names = "shutdown_flag", "boot_stage",
+				"boot_error_count", "panic_count", "pm_setting";
+		};
+	};
+
 	smc_mbox: mbox@290408000 {
 		compatible = "apple,t6000-asc-mailbox", "apple,asc-mailbox-v4";
 		reg = <0x2 0x90408000 0x0 0x4000>;
@@ -51,31 +83,6 @@
 		interrupt-names = "send-empty", "send-not-empty",
 			"recv-empty", "recv-not-empty";
 		#mbox-cells = <0>;
-	};
-
-	smc: smc@290400000 {
-		compatible = "apple,t6000-smc", "apple,smc";
-		reg = <0x2 0x90400000 0x0 0x4000>,
-			<0x2 0x91e00000 0x0 0x100000>;
-		reg-names = "smc", "sram";
-		mboxes = <&smc_mbox>;
-
-		smc_gpio: gpio {
-			gpio-controller;
-			#gpio-cells = <2>;
-		};
-
-		smc_rtc: rtc {
-			nvmem-cells = <&rtc_offset>;
-			nvmem-cell-names = "rtc_offset";
-		};
-
-		smc_reboot: reboot {
-			nvmem-cells = <&shutdown_flag>, <&boot_stage>,
-				<&boot_error_count>, <&panic_count>, <&pm_setting>;
-			nvmem-cell-names = "shutdown_flag", "boot_stage",
-				"boot_error_count", "panic_count", "pm_setting";
-		};
 	};
 
 	pinctrl_smc: pinctrl@290820000 {
@@ -99,6 +106,63 @@
 				<AIC_IRQ 0 749 IRQ_TYPE_LEVEL_HIGH>;
 	};
 
+	nub_spmi0: spmi@2920a1300 {
+		compatible = "apple,t6000-spmi", "apple,spmi";
+		reg = <0x2 0x920a1300 0x0 0x100>;
+		#address-cells = <2>;
+		#size-cells = <0>;
+
+		pmic1: pmic@f {
+			compatible = "apple,maverick-pmic", "apple,spmi-nvmem";
+			reg = <0xf SPMI_USID>;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				pm_setting: pm-setting@1405 {
+					reg = <0x1405 0x1>;
+				};
+
+				rtc_offset: rtc-offset@1411 {
+					reg = <0x1411 0x6>;
+				};
+
+				boot_stage: boot-stage@6001 {
+					reg = <0x6001 0x1>;
+				};
+
+				boot_error_count: boot-error-count@6002,0 {
+					reg = <0x6002 0x1>;
+					bits = <0 4>;
+				};
+
+				panic_count: panic-count@6002,4 {
+					reg = <0x6002 0x1>;
+					bits = <4 4>;
+				};
+
+				boot_error_stage: boot-error-stage@6003 {
+					reg = <0x6003 0x1>;
+				};
+
+				shutdown_flag: shutdown-flag@600f,3 {
+					reg = <0x600f 0x1>;
+					bits = <3 1>;
+				};
+
+				fault_shadow: fault-shadow@867b {
+					reg = <0x867b 0x10>;
+				};
+
+				socd: socd@8b00 {
+					reg = <0x8b00 0x400>;
+				};
+			};
+		};
+	};
+
 	wdt: watchdog@2922b0000 {
 		compatible = "apple,t6000-wdt", "apple,wdt";
 		reg = <0x2 0x922b0000 0x0 0x4000>;
@@ -107,78 +171,65 @@
 		interrupts = <AIC_IRQ 0 631 IRQ_TYPE_LEVEL_HIGH>;
 	};
 
-	nub_spmi0: spmi@2920a1300 {
-		compatible = "apple,t6000-spmi", "apple,spmi";
-		reg = <0x2 0x920a1300 0x0 0x100>;
-		#address-cells = <2>;
-		#size-cells = <0>;
+	aop_mbox: mbox@293408000 {
+		compatible = "apple,t6000-asc-mailbox", "apple,asc-mailbox-v4";
+		reg = <0x2 0x93408000 0x0 0x4000>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ 0 582 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ 0 583 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ 0 584 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ 0 585 IRQ_TYPE_LEVEL_HIGH>;
+		interrupt-names = "send-empty", "send-not-empty",
+			"recv-empty", "recv-not-empty";
+		#mbox-cells = <0>;
+		status = "disabled";
+	};
 
-		pmu1: pmu@f {
-			compatible = "apple,maverick-pmu", "apple,spmi-pmu";
-			reg = <0xf SPMI_USID>;
-			#address-cells = <1>;
-			#size-cells = <1>;
+	aop_dart: iommu@293808000 {
+		compatible = "apple,t6000-dart";
+		reg = <0x2 0x93808000 0x0 0x4000>;
+		#iommu-cells = <1>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ 0 597 IRQ_TYPE_LEVEL_HIGH>;
+		status = "disabled";
+	};
 
-			rtc_nvmem@1400 {
-				compatible = "apple,spmi-pmu-nvmem";
-				reg = <0x1400 0x20>;
-				#address-cells = <1>;
-				#size-cells = <1>;
+	aop_admac: dma-controller@293980000 {
+		compatible = "apple,t6000-admac", "apple,admac";
+		reg = <0x2 0x93980000 0x0 0x34000>;
+		#dma-cells = <1>;
+		dma-channels = <16>;
+		interrupts-extended = <0>,
+				      <0>,
+				      <&aic AIC_IRQ 0 600 IRQ_TYPE_LEVEL_HIGH>,
+				      <0>;
+		iommus = <&aop_dart 7>;
+		status = "disabled";
+	};
 
-				pm_setting: pm-setting@5 {
-					reg = <0x5 0x1>;
-				};
+	aop: aop@293c00000 {
+		compatible = "apple,t6000-aop";
+		reg = <0x2 0x93c00000 0x0 0x250000>,
+		      <0x2 0x93400000 0x0 0x6c000>;
+		mboxes = <&aop_mbox>;
+		mbox-names = "mbox";
+		iommus = <&aop_dart 0>;
 
-				rtc_offset: rtc-offset@11 {
-					reg = <0x11 0x6>;
-				};
-			};
+		status = "disabled";
 
-			legacy_nvmem@6000 {
-				compatible = "apple,spmi-pmu-nvmem";
-				reg = <0x6000 0x20>;
-				#address-cells = <1>;
-				#size-cells = <1>;
+		aop_audio: audio {
+			compatible = "apple,t6000-aop-audio", "apple,aop-audio";
+			dmas = <&aop_admac 1>;
+			dma-names = "dma";
+		};
 
-				boot_stage: boot-stage@1 {
-					reg = <0x1 0x1>;
-				};
+		aop_als: als {
+			compatible = "apple,t6000-aop-als", "apple,aop-als";
+			// intentionally empty
+		};
 
-				boot_error_count: boot-error-count@2 {
-					reg = <0x2 0x1>;
-					bits = <0 4>;
-				};
-
-				panic_count: panic-count@2 {
-					reg = <0x2 0x1>;
-					bits = <4 4>;
-				};
-
-				boot_error_stage: boot-error-stage@3 {
-					reg = <0x3 0x1>;
-				};
-
-				shutdown_flag: shutdown-flag@f {
-					reg = <0xf 0x1>;
-					bits = <3 1>;
-				};
-			};
-
-			scrpad_nvmem@8000 {
-				compatible = "apple,spmi-pmu-nvmem";
-				reg = <0x8000 0x1000>;
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				fault_shadow: fault-shadow@67b {
-					reg = <0x67b 0x10>;
-				};
-
-				socd: socd@b00 {
-					reg = <0xb00 0x400>;
-				};
-			};
-
+		las {
+			compatible = "apple,t6000-aop-las", "apple,aop-las";
 		};
 	};
 
@@ -201,6 +252,58 @@
 		interrupts = <AIC_IRQ 0 821 IRQ_TYPE_LEVEL_HIGH>;
 		power-domains = <&ps_disp0_cpu0>;
 		apple,dma-range = <0x1f0 0x0 0x0 0xfc000000>;
+	};
+
+	sep_dart: iommu@3952c0000 {
+		compatible = "apple,t6000-dart";
+		reg = <0x3 0x952c0000 0x0 0x4000>;
+		#iommu-cells = <1>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ 0 551 IRQ_TYPE_LEVEL_HIGH>;
+	};
+
+	sep: sep@396400000 {
+		compatible = "apple,sep";
+		reg = <0x3 0x96400000 0x0 0x6C000>;
+		mboxes = <&sep_mbox>;
+		mbox-names = "mbox";
+		iommus = <&sep_dart 0>;
+		power-domains = <&ps_sep>;
+		status = "disabled";
+	};
+
+	sep_mbox: mbox@396408000 {
+		compatible = "apple,t6000-asc-mailbox", "apple,asc-mailbox-v4";
+		reg = <0x3 0x96408000 0x0 0x4000>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ 0 545 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ 0 546 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ 0 547 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ 0 548 IRQ_TYPE_LEVEL_HIGH>;
+		interrupt-names = "send-empty", "send-not-empty",
+			"recv-empty", "recv-not-empty";
+		#mbox-cells = <0>;
+	};
+
+	dpaudio0: audio-controller@39b500000 {
+		compatible = "apple,t6000-dpaudio", "apple,dpaudio";
+		reg = <0x3 0x9b500000 0x0 0x4000>;
+		dmas = <&sio 0x64>;
+		dma-names = "tx";
+		power-domains = <&ps_dpa0>;
+		reset-domains = <&ps_dpa0>;
+		status = "disabled";
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port@0 {
+				reg = <0>;
+				dpaudio0_dcp: endpoint {
+					remote-endpoint = <&dcp_audio>;
+				};
+			};
+		};
 	};
 
 	dcp_mbox: mbox@38bc08000 {
@@ -234,10 +337,24 @@
 		resets = <&ps_disp0_cpu0>;
 		clocks = <&clk_disp0>;
 		phandle = <&dcp>;
+		// required bus properties for 'piodma' subdevice
+		#address-cells = <2>;
+		#size-cells = <2>;
 
 		disp0_piodma: piodma {
 			iommus = <&disp0_dart 4>;
 			phandle = <&disp0_piodma>;
+		};
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port@0 {
+				reg = <0>;
+				dcp_audio: endpoint {
+					remote-endpoint = <&dpaudio0_dcp>;
+				};
+			};
 		};
 	};
 
@@ -246,24 +363,6 @@
 		iommus = <&disp0_dart 0>;
 		/* generate phandle explicitly for use in loader */
 		phandle = <&display>;
-	};
-
-	sio_dart_0: iommu@39b004000 {
-		compatible = "apple,t6000-dart";
-		reg = <0x3 0x9b004000 0x0 0x4000>;
-		interrupt-parent = <&aic>;
-		interrupts = <AIC_IRQ 0 1130 IRQ_TYPE_LEVEL_HIGH>;
-		#iommu-cells = <1>;
-		power-domains = <&ps_sio_cpu>;
-	};
-
-	sio_dart_1: iommu@39b008000 {
-		compatible = "apple,t6000-dart";
-		reg = <0x3 0x9b008000 0x0 0x8000>;
-		interrupt-parent = <&aic>;
-		interrupts = <AIC_IRQ 0 1130 IRQ_TYPE_LEVEL_HIGH>;
-		#iommu-cells = <1>;
-		power-domains = <&ps_sio_cpu>;
 	};
 
 	fpwm0: pwm@39b030000 {
@@ -369,6 +468,7 @@
 		pinctrl-0 = <&spi1_pins>;
 		pinctrl-names = "default";
 		power-domains = <&ps_spi1>;
+		status = "disabled";
 	};
 
 	spi3: spi@39b10c000 {
@@ -440,20 +540,18 @@
 	};
 
 	gpu: gpu@406400000 {
-		compatible = "apple,agx-g13x";
+		compatible = "apple,agx-g13s";
 		reg = <0x4 0x6400000 0 0x40000>,
 			<0x4 0x4000000 0 0x1000000>;
 		reg-names = "asc", "sgx";
-		interrupt-parent = <&aic>;
-		interrupts = <AIC_IRQ 0 1044 IRQ_TYPE_LEVEL_HIGH>,
-			<AIC_IRQ 0 1045 IRQ_TYPE_LEVEL_HIGH>,
-			<AIC_IRQ 0 1046 IRQ_TYPE_LEVEL_HIGH>,
-			<AIC_IRQ 0 1047 IRQ_TYPE_LEVEL_HIGH>,
-			<AIC_IRQ 0 1063 IRQ_TYPE_LEVEL_HIGH>;
 		mboxes = <&agx_mbox>;
 		power-domains = <&ps_gfx>;
-		memory-region = <&uat_ttbs>, <&uat_pagetables>, <&uat_handoff>;
-		memory-region-names = "ttbs", "pagetables", "handoff";
+		memory-region = <&uat_ttbs>, <&uat_pagetables>, <&uat_handoff>,
+				<&gpu_hw_cal_a>, <&gpu_hw_cal_b>, <&gpu_globals>;
+		memory-region-names = "ttbs", "pagetables", "handoff",
+				      "hw-cal-a", "hw-cal-b", "globals";
+
+		apple,firmware-abi = <0 0 0>;
 
 		apple,firmware-version = <12 3 0>;
 		apple,firmware-compat = <12 3 0>;
@@ -481,7 +579,7 @@
 		apple,perf-tgt-utilization = <85>;
 		apple,power-sample-period = <8>;
 		apple,ppm-filter-time-constant-ms = <100>;
-		apple,ppm-ki = <30>;
+		apple,ppm-ki = <30.0>;
 		apple,ppm-kp = <1.5>;
 		apple,pwr-filter-time-constant = <313>;
 		apple,pwr-integral-gain = <0.0202129>;

--- a/arch/arm/dts/t600x-dieX.dtsi
+++ b/arch/arm/dts/t600x-dieX.dtsi
@@ -81,9 +81,100 @@
 		phandle = <&DIE_NODE(dcpext0)>;
 		apple,dcp-index = <1>;
 		status = "disabled";
+		// required bus properties for 'piodma' subdevice
+		#address-cells = <2>;
+		#size-cells = <2>;
 
 		piodma {
 			iommus = <&DIE_NODE(dispext0_dart) 4>;
+		};
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port@0 {
+				reg = <0>;
+				DIE_NODE(dcpext0_audio): endpoint {
+					remote-endpoint = <&DIE_NODE(dpaudio1_dcp)>;
+				};
+			};
+		};
+	};
+
+	DIE_NODE(dispext1_dart): iommu@28c304000 {
+		compatible = "apple,t6000-dart", "apple,t8110-dart";
+		reg = <0x2 0x8c304000 0x0 0x4000>;
+		#iommu-cells = <1>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 909 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&DIE_NODE(ps_dispext1_cpu0)>;
+		apple,dma-range = <0x0 0x0 0x0 0xfc000000>;
+		status = "disabled";
+	};
+
+	DIE_NODE(dcpext1_dart): iommu@28c30c000 {
+		compatible = "apple,t6000-dart", "apple,t8110-dart";
+		reg = <0x2 0x8c30c000 0x0 0x4000>;
+		#iommu-cells = <1>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 909 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&DIE_NODE(ps_dispext1_cpu0)>;
+		apple,dma-range = <0x1f0 0x0 0x0 0xfc000000>;
+		status = "disabled";
+	};
+
+	DIE_NODE(dcpext1_mbox): mbox@28cc08000 {
+		compatible = "apple,t6000-asc-mailbox", "apple,asc-mailbox-v4";
+		reg = <0x2 0x8cc08000 0x0 0x4000>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 930 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ DIE_NO 931 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ DIE_NO 932 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ DIE_NO 933 IRQ_TYPE_LEVEL_HIGH>;
+		interrupt-names = "send-empty", "send-not-empty",
+			"recv-empty", "recv-not-empty";
+		#mbox-cells = <0>;
+		power-domains = <&DIE_NODE(ps_dispext1_cpu0)>;
+		resets = <&DIE_NODE(ps_dispext1_cpu0)>;
+		status = "disabled";
+	};
+
+	DIE_NODE(dcpext1):  dcp@28cc00000 {
+		compatible = "apple,t6000-dcpext", "apple,dcpext";
+		mboxes = <&DIE_NODE(dcpext1_mbox)>;
+		mbox-names = "mbox";
+		iommus = <&DIE_NODE(dcpext1_dart) 0>;
+
+		reg-names = "coproc", "disp-0", "disp-1", "disp-2", "disp-3";
+		reg = <0x2 0x8cc00000 0x0 0x4000>,
+			<0x2 0x8b000000 0x0 0x3000000>,
+			<0x2 0x8c320000 0x0 0x4000>,
+			<0x2 0x8c344000 0x0 0x4000>,
+			<0x2 0x8c800000 0x0 0x800000>;
+		apple,bw-scratch = <&pmgr_dcp 0 4 0x998>;
+		power-domains = <&DIE_NODE(ps_dispext1_cpu0)>;
+		resets = <&DIE_NODE(ps_dispext1_cpu0)>;
+		clocks = <&DIE_NODE(clk_dispext1)>;
+		phandle = <&DIE_NODE(dcpext1)>;
+		apple,dcp-index = <2>;
+		status = "disabled";
+		// required bus properties for 'piodma' subdevice
+		#address-cells = <2>;
+		#size-cells = <2>;
+
+		piodma {
+			iommus = <&DIE_NODE(dispext1_dart) 4>;
+		};
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port@0 {
+				reg = <0>;
+				DIE_NODE(dcpext1_audio): endpoint {
+					remote-endpoint = <&DIE_NODE(dpaudio2_dcp)>;
+				};
+			};
 		};
 	};
 
@@ -345,67 +436,22 @@
 				<AIC_IRQ DIE_NO 573 IRQ_TYPE_LEVEL_HIGH>;
 	};
 
-	DIE_NODE(dispext1_dart): iommu@315304000 {
-		compatible = "apple,t6000-dart", "apple,t8110-dart";
-		reg = <0x3 0x15304000 0x0 0x4000>;
+	DIE_NODE(sio_dart_0): iommu@39b004000 {
+		compatible = "apple,t6000-dart";
+		reg = <0x3 0x9b004000 0x0 0x4000>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1130 IRQ_TYPE_LEVEL_HIGH>;
 		#iommu-cells = <1>;
-		interrupt-parent = <&aic>;
-		interrupts = <AIC_IRQ DIE_NO 950 IRQ_TYPE_LEVEL_HIGH>;
-		power-domains = <&DIE_NODE(ps_dispext1_cpu0)>;
-		apple,dma-range = <0x100 0x0 0x10 0x0>;
-		status = "disabled";
+		power-domains = <&DIE_NODE(ps_sio_cpu)>;
 	};
 
-	DIE_NODE(dcpext1_dart): iommu@31530c000 {
-		compatible = "apple,t6000-dart", "apple,t8110-dart";
-		reg = <0x3 0x1530c000 0x0 0x4000>;
+	DIE_NODE(sio_dart_1): iommu@39b008000 {
+		compatible = "apple,t6000-dart";
+		reg = <0x3 0x9b008000 0x0 0x8000>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1130 IRQ_TYPE_LEVEL_HIGH>;
 		#iommu-cells = <1>;
-		interrupt-parent = <&aic>;
-		interrupts = <AIC_IRQ DIE_NO 950 IRQ_TYPE_LEVEL_HIGH>;
-		power-domains = <&DIE_NODE(ps_dispext1_cpu0)>;
-		apple,dma-range = <0x100 0x0 0x10 0x0>;
-		status = "disabled";
-	};
-
-	DIE_NODE(dcpext1_mbox): mbox@315c08000 {
-		compatible = "apple,t6000-asc-mailbox", "apple,asc-mailbox-v4";
-		reg = <0x3 0x15c08000 0x0 0x4000>;
-		interrupt-parent = <&aic>;
-		interrupts = <AIC_IRQ DIE_NO 1007 IRQ_TYPE_LEVEL_HIGH>,
-			<AIC_IRQ DIE_NO 1008 IRQ_TYPE_LEVEL_HIGH>,
-			<AIC_IRQ DIE_NO 1009 IRQ_TYPE_LEVEL_HIGH>,
-			<AIC_IRQ DIE_NO 1010 IRQ_TYPE_LEVEL_HIGH>;
-		interrupt-names = "send-empty", "send-not-empty",
-			"recv-empty", "recv-not-empty";
-		#mbox-cells = <0>;
-		power-domains = <&DIE_NODE(ps_dispext1_cpu0)>;
-		resets = <&DIE_NODE(ps_dispext1_cpu0)>;
-		status = "disabled";
-	};
-
-	DIE_NODE(dcpext1):  dcp@315c00000 {
-		compatible = "apple,t6000-dcpext", "apple,dcpext";
-		mboxes = <&DIE_NODE(dcpext1_mbox)>;
-		mbox-names = "mbox";
-		iommus = <&DIE_NODE(dcpext1_dart) 5>;
-
-		reg-names = "coproc", "disp-0", "disp-1", "disp-2", "disp-3";
-		reg = <0x3 0x15c00000 0x0 0x4000>,
-			<0x3 0x14000000 0x0 0x4000000>,
-			<0x3 0x15320000 0x0 0x4000>,
-			<0x3 0x15344000 0x0 0x4000>,
-			<0x3 0x15800000 0x0 0x800000>;
-		apple,bw-scratch = <&pmgr_dcp 0 4 0x998>;
-		power-domains = <&DIE_NODE(ps_dispext1_cpu0)>;
-		resets = <&DIE_NODE(ps_dispext1_cpu0)>;
-		clocks = <&DIE_NODE(clk_dispext1)>;
-		phandle = <&DIE_NODE(dcpext1)>;
-		apple,dcp-index = <2>;
-		status = "disabled";
-
-		piodma {
-			iommus = <&DIE_NODE(dispext1_dart) 4>;
-		};
+		power-domains = <&DIE_NODE(ps_sio_cpu)>;
 	};
 
 	DIE_NODE(pinctrl_ap): pinctrl@39b028000 {
@@ -433,6 +479,137 @@
 		#interrupt-cells = <2>;
 	};
 
+	DIE_NODE(sio_mbox): mbox@39bc08000 {
+		compatible = "apple,t6000-asc-mailbox", "apple,asc-mailbox-v4";
+		reg = <0x3 0x9bc08000 0x0 0x4000>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1147 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ DIE_NO 1148 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ DIE_NO 1149 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ DIE_NO 1150 IRQ_TYPE_LEVEL_HIGH>;
+		interrupt-names = "send-empty", "send-not-empty",
+			"recv-empty", "recv-not-empty";
+		#mbox-cells = <0>;
+		power-domains = <&DIE_NODE(ps_sio_cpu)>;
+	};
+
+	DIE_NODE(sio): sio@39bc00000 {
+		compatible = "apple,t6000-sio", "apple,sio";
+		reg = <0x3 0x9bc00000 0x0 0x8000>;
+		dma-channels = <128>;
+		#dma-cells = <1>;
+		mboxes = <&DIE_NODE(sio_mbox)>;
+		iommus = <&DIE_NODE(sio_dart_0) 0>, <&DIE_NODE(sio_dart_1) 0>;
+		power-domains = <&DIE_NODE(ps_sio_cpu)>;
+		resets = <&DIE_NODE(ps_sio)>; /* TODO: verify reset does something */
+		status = "disabled";
+	};
+
+	DIE_NODE(dpaudio1): audio-controller@39b504000 {
+		compatible = "apple,t6000-dpaudio", "apple,dpaudio";
+		reg = <0x3 0x9b540000 0x0 0x4000>;
+		dmas = <&DIE_NODE(sio) 0x66>;
+		dma-names = "tx";
+		power-domains = <&DIE_NODE(ps_dpa1)>;
+		reset-domains = <&DIE_NODE(ps_dpa1)>;
+		status = "disabled";
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port@0 {
+				reg = <0>;
+				DIE_NODE(dpaudio1_dcp): endpoint {
+					remote-endpoint = <&DIE_NODE(dcpext0_audio)>;
+				};
+			};
+		};
+	};
+
+	DIE_NODE(dpaudio2): audio-controller@39b508000 {
+		compatible = "apple,t6000-dpaudio", "apple,dpaudio";
+		reg = <0x3 0x9b580000 0x0 0x4000>;
+		dmas = <&DIE_NODE(sio) 0x68>;
+		dma-names = "tx";
+		power-domains = <&DIE_NODE(ps_dpa2)>;
+		reset-domains = <&DIE_NODE(ps_dpa2)>;
+		status = "disabled";
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port@0 {
+				reg = <0>;
+				DIE_NODE(dpaudio2_dcp): endpoint {
+					remote-endpoint = <&DIE_NODE(dcpext1_audio)>;
+				};
+			};
+		};
+	};
+
+	/*
+	 * omit dpaudio3 / 4 as long as the linked dcpext nodes don't exist
+	 *
+	DIE_NODE(dpaudio3): audio-controller@39b50c000 {
+		compatible = "apple,t6000-dpaudio", "apple,dpaudio";
+		reg = <0x3 0x9b5c0000 0x0 0x4000>;
+		dmas = <&DIE_NODE(sio) 0x6a>;
+		dma-names = "tx";
+		power-domains = <&DIE_NODE(ps_dpa3)>;
+		reset-domains = <&DIE_NODE(ps_dpa3)>;
+		status = "disabled";
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port@0 {
+				reg = <0>;
+				DIE_NODE(dpaudio3_dcp): endpoint {
+					remote-endpoint = <&DIE_NODE(dcpext2_audio)>;
+				};
+			};
+		};
+	};
+
+	DIE_NODE(dpaudio4): audio-controller@39b510000 {
+		compatible = "apple,t6000-dpaudio", "apple,dpaudio";
+		reg = <0x3 0x9b500000 0x0 0x4000>;
+		dmas = <&DIE_NODE(sio) 0x6c>;
+		dma-names = "tx";
+		power-domains = <&DIE_NODE(ps_dpa4)>;
+		reset-domains = <&DIE_NODE(ps_dpa4)>;
+		status = "disabled";
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port@0 {
+				reg = <0>;
+				DIE_NODE(dpaudio4_dcp): endpoint {
+					remote-endpoint = <&DIE_NODE(dcpext3_audio)>;
+				};
+			};
+		};
+	};
+	*/
+
+	DIE_NODE(dwc3_0): usb@702280000 {
+		compatible = "apple,t6000-dwc3", "apple,t8103-dwc3";
+		reg = <0x7 0x02280000 0x0 0xcd00>, <0x7 0x0228cd00 0x0 0x3200>;
+		reg-names = "dwc3-core", "dwc3-apple";
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1190 IRQ_TYPE_LEVEL_HIGH>;
+		dr_mode = "otg";
+		usb-role-switch;
+		role-switch-default-mode = "host";
+		iommus = <&DIE_NODE(dwc3_0_dart_0) 0>,
+			<&DIE_NODE(dwc3_0_dart_1) 1>;
+		power-domains = <&DIE_NODE(ps_atc0_usb)>;
+		resets = <&DIE_NODE(atcphy0)>;
+		phys = <&DIE_NODE(atcphy0) PHY_TYPE_USB2>, <&DIE_NODE(atcphy0) PHY_TYPE_USB3>;
+		phy-names = "usb2-phy", "usb3-phy";
+	};
+
 	DIE_NODE(dwc3_0_dart_0): iommu@702f00000 {
 		compatible = "apple,t6000-dart";
 		reg = <0x7 0x02f00000 0x0 0x4000>;
@@ -449,23 +626,6 @@
 		interrupts = <AIC_IRQ DIE_NO 1194 IRQ_TYPE_LEVEL_HIGH>;
 		power-domains = <&DIE_NODE(ps_atc0_usb)>;
 		#iommu-cells = <1>;
-	};
-
-	DIE_NODE(dwc3_0): usb@702280000 {
-		compatible = "apple,t6000-dwc3", "apple,dwc3", "snps,dwc3";
-		reg = <0x7 0x02280000 0x0 0x100000>;
-		interrupt-parent = <&aic>;
-		interrupts = <AIC_IRQ DIE_NO 1190 IRQ_TYPE_LEVEL_HIGH>;
-		dr_mode = "otg";
-		usb-role-switch;
-		role-switch-default-mode = "host";
-		iommus = <&DIE_NODE(dwc3_0_dart_0) 0>,
-			<&DIE_NODE(dwc3_0_dart_1) 1>;
-		power-domains = <&DIE_NODE(ps_atc0_usb)>;
-		dma-coherent;
-		resets = <&DIE_NODE(atcphy0)>;
-		phys = <&DIE_NODE(atcphy0) PHY_TYPE_USB2>, <&DIE_NODE(atcphy0) PHY_TYPE_USB3>;
-		phy-names = "usb2-phy", "usb3-phy";
 	};
 
 	DIE_NODE(atcphy0): phy@703000000 {
@@ -502,7 +662,6 @@
 
 		orientation-switch;
 		mode-switch;
-		svid = <0xff01>, <0x8087>;
 		power-domains = <&DIE_NODE(ps_atc0_usb)>;
 	};
 
@@ -512,6 +671,23 @@
 		#mux-control-cells = <1>;
 		power-domains = <&DIE_NODE(ps_atc0_usb)>;
 		status = "disabled";
+	};
+
+	DIE_NODE(dwc3_1): usb@b02280000 {
+		compatible = "apple,t6000-dwc3", "apple,t8103-dwc3";
+		reg = <0xb 0x02280000 0x0 0xcd00>, <0xb 0x0228cd00 0x0 0x3200>;
+		reg-names = "dwc3-core", "dwc3-apple";
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1207 IRQ_TYPE_LEVEL_HIGH>;
+		dr_mode = "otg";
+		usb-role-switch;
+		role-switch-default-mode = "host";
+		iommus = <&DIE_NODE(dwc3_1_dart_0) 0>,
+			<&DIE_NODE(dwc3_1_dart_1) 1>;
+		power-domains = <&DIE_NODE(ps_atc1_usb)>;
+		resets = <&DIE_NODE(atcphy1)>;
+		phys = <&DIE_NODE(atcphy1) PHY_TYPE_USB2>, <&DIE_NODE(atcphy1) PHY_TYPE_USB3>;
+		phy-names = "usb2-phy", "usb3-phy";
 	};
 
 	DIE_NODE(dwc3_1_dart_0): iommu@b02f00000 {
@@ -530,23 +706,6 @@
 		interrupts = <AIC_IRQ DIE_NO 1211 IRQ_TYPE_LEVEL_HIGH>;
 		power-domains = <&DIE_NODE(ps_atc1_usb)>;
 		#iommu-cells = <1>;
-	};
-
-	DIE_NODE(dwc3_1): usb@b02280000 {
-		compatible = "apple,t6000-dwc3", "apple,dwc3", "snps,dwc3";
-		reg = <0xb 0x02280000 0x0 0x100000>;
-		interrupt-parent = <&aic>;
-		interrupts = <AIC_IRQ DIE_NO 1207 IRQ_TYPE_LEVEL_HIGH>;
-		dr_mode = "otg";
-		usb-role-switch;
-		role-switch-default-mode = "host";
-		iommus = <&DIE_NODE(dwc3_1_dart_0) 0>,
-			<&DIE_NODE(dwc3_1_dart_1) 1>;
-		power-domains = <&DIE_NODE(ps_atc1_usb)>;
-		dma-coherent;
-		resets = <&DIE_NODE(atcphy1)>;
-		phys = <&DIE_NODE(atcphy1) PHY_TYPE_USB2>, <&DIE_NODE(atcphy1) PHY_TYPE_USB3>;
-		phy-names = "usb2-phy", "usb3-phy";
 	};
 
 	DIE_NODE(atcphy1): phy@b03000000 {
@@ -583,7 +742,6 @@
 
 		orientation-switch;
 		mode-switch;
-		svid = <0xff01>, <0x8087>;
 		power-domains = <&DIE_NODE(ps_atc1_usb)>;
 	};
 
@@ -593,6 +751,23 @@
 		#mux-control-cells = <1>;
 		power-domains = <&DIE_NODE(ps_atc1_usb)>;
 		status = "disabled";
+	};
+
+	DIE_NODE(dwc3_2): usb@f02280000 {
+		compatible = "apple,t6000-dwc3", "apple,t8103-dwc3";
+		reg = <0xf 0x02280000 0x0 0xcd00>, <0xf 0x0228cd00 0x0 0x3200>;
+		reg-names = "dwc3-core", "dwc3-apple";
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1224 IRQ_TYPE_LEVEL_HIGH>;
+		dr_mode = "otg";
+		usb-role-switch;
+		role-switch-default-mode = "host";
+		iommus = <&DIE_NODE(dwc3_2_dart_0) 0>,
+			<&DIE_NODE(dwc3_2_dart_1) 1>;
+		power-domains = <&DIE_NODE(ps_atc2_usb)>;
+		resets = <&DIE_NODE(atcphy2)>;
+		phys = <&DIE_NODE(atcphy2) PHY_TYPE_USB2>, <&DIE_NODE(atcphy2) PHY_TYPE_USB3>;
+		phy-names = "usb2-phy", "usb3-phy";
 	};
 
 	DIE_NODE(dwc3_2_dart_0): iommu@f02f00000 {
@@ -611,23 +786,6 @@
 		interrupts = <AIC_IRQ DIE_NO 1228 IRQ_TYPE_LEVEL_HIGH>;
 		power-domains = <&DIE_NODE(ps_atc2_usb)>;
 		#iommu-cells = <1>;
-	};
-
-	DIE_NODE(dwc3_2): usb@f02280000 {
-		compatible = "apple,t6000-dwc3", "apple,dwc3", "snps,dwc3";
-		reg = <0xf 0x02280000 0x0 0x100000>;
-		interrupt-parent = <&aic>;
-		interrupts = <AIC_IRQ DIE_NO 1224 IRQ_TYPE_LEVEL_HIGH>;
-		dr_mode = "otg";
-		usb-role-switch;
-		role-switch-default-mode = "host";
-		iommus = <&DIE_NODE(dwc3_2_dart_0) 0>,
-			<&DIE_NODE(dwc3_2_dart_1) 1>;
-		power-domains = <&DIE_NODE(ps_atc2_usb)>;
-		dma-coherent;
-		resets = <&DIE_NODE(atcphy2)>;
-		phys = <&DIE_NODE(atcphy2) PHY_TYPE_USB2>, <&DIE_NODE(atcphy2) PHY_TYPE_USB3>;
-		phy-names = "usb2-phy", "usb3-phy";
 	};
 
 	DIE_NODE(atcphy2): phy@f03000000 {
@@ -664,7 +822,6 @@
 
 		orientation-switch;
 		mode-switch;
-		svid = <0xff01>, <0x8087>;
 		power-domains = <&DIE_NODE(ps_atc2_usb)>;
 	};
 
@@ -674,6 +831,23 @@
 		#mux-control-cells = <1>;
 		power-domains = <&DIE_NODE(ps_atc2_usb)>;
 		status = "disabled";
+	};
+
+	DIE_NODE(dwc3_3): usb@1302280000 {
+		compatible = "apple,t6000-dwc3", "apple,t8103-dwc3";
+		reg = <0x13 0x02280000 0x0 0xcd00>, <0x13 0x0228cd00 0x0 0x3200>;
+		reg-names = "dwc3-core", "dwc3-apple";
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1241 IRQ_TYPE_LEVEL_HIGH>;
+		dr_mode = "otg";
+		usb-role-switch;
+		role-switch-default-mode = "host";
+		iommus = <&DIE_NODE(dwc3_3_dart_0) 0>,
+			<&DIE_NODE(dwc3_3_dart_1) 1>;
+		power-domains = <&DIE_NODE(ps_atc3_usb)>;
+		resets = <&DIE_NODE(atcphy3)>;
+		phys = <&DIE_NODE(atcphy3) PHY_TYPE_USB2>, <&DIE_NODE(atcphy3) PHY_TYPE_USB3>;
+		phy-names = "usb2-phy", "usb3-phy";
 	};
 
 	DIE_NODE(dwc3_3_dart_0): iommu@1302f00000 {
@@ -692,23 +866,6 @@
 		interrupts = <AIC_IRQ DIE_NO 1245 IRQ_TYPE_LEVEL_HIGH>;
 		power-domains = <&DIE_NODE(ps_atc3_usb)>;
 		#iommu-cells = <1>;
-	};
-
-	DIE_NODE(dwc3_3): usb@1302280000 {
-		compatible = "apple,t6000-dwc3", "apple,dwc3", "snps,dwc3";
-		reg = <0x13 0x02280000 0x0 0x100000>;
-		interrupt-parent = <&aic>;
-		interrupts = <AIC_IRQ DIE_NO 1241 IRQ_TYPE_LEVEL_HIGH>;
-		dr_mode = "otg";
-		usb-role-switch;
-		role-switch-default-mode = "host";
-		iommus = <&DIE_NODE(dwc3_3_dart_0) 0>,
-			<&DIE_NODE(dwc3_3_dart_1) 1>;
-		power-domains = <&DIE_NODE(ps_atc3_usb)>;
-		dma-coherent;
-		resets = <&DIE_NODE(atcphy3)>;
-		phys = <&DIE_NODE(atcphy3) PHY_TYPE_USB2>, <&DIE_NODE(atcphy3) PHY_TYPE_USB3>;
-		phy-names = "usb2-phy", "usb3-phy";
 	};
 
 	DIE_NODE(atcphy3): phy@1303000000 {
@@ -745,7 +902,6 @@
 
 		orientation-switch;
 		mode-switch;
-		svid = <0xff01>, <0x8087>;
 		power-domains = <&DIE_NODE(ps_atc3_usb)>;
 	};
 

--- a/arch/arm/dts/t600x-j314-j316.dtsi
+++ b/arch/arm/dts/t600x-j314-j316.dtsi
@@ -12,6 +12,8 @@
 #include <dt-bindings/leds/common.h>
 
 / {
+	chassis-type = "laptop";
+
 	aliases {
 		atcphy0 = &atcphy0;
 		atcphy1 = &atcphy1;
@@ -22,8 +24,8 @@
 		dcpext0 = &dcpext0;
 		disp0 = &display;
 		disp0_piodma = &disp0_piodma;
-		nvram = &nvram;
 		serial0 = &serial0;
+		sio = &sio;
 		wifi0 = &wifi0;
 	};
 
@@ -39,15 +41,10 @@
 			reg = <0 0 0 0>; /* To be filled by loader */
 			/* Format properties will be added by loader */
 			status = "disabled";
+			panel = <&panel>;
+			post-init-providers = <&panel>;
 			power-domains = <&ps_disp0_cpu0>;
 		};
-	};
-
-	reserved-memory {
-		#address-cells = <2>;
-		#size-cells = <2>;
-		ranges;
-		/* To be filled by loader */
 	};
 
 	memory@10000000000 {
@@ -104,21 +101,42 @@
 	hdmi-pwren-gpios = <&smc_gpio 23 GPIO_ACTIVE_HIGH>;
 	dp2hdmi-pwren-gpios = <&smc_gpio 6 GPIO_ACTIVE_HIGH>;
 
-	phy-names = "dp-phy";
 	phys = <&atcphy3 PHY_TYPE_DP>;
 	phy-names = "dp-phy";
 	mux-controls = <&atcphy3_xbar 0>;
 	mux-control-names = "dp-xbar";
 	mux-index = <0>;
 	apple,dptx-phy = <3>;
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@1 {
+			reg = <1>;
+
+			decpext0_dpout: endpoint {
+				remote-endpoint = <&atcphy3_dp>;
+			};
+		};
+	};
 };
 
-&atcphy3 {
-	apple,mode-fixed-dp;
+/* remove once m1n1 enables sio nodes after setup */
+&sio {
+        status = "okay";
+};
+
+&dpaudio1 {
+	status = "okay";
 };
 
 &atcphy3_xbar {
 	status = "okay";
+};
+
+&ps_atc3_common {
+	apple,always-on; /* Needs to stay on for HDMI resume */
 };
 
 /* USB Type C */
@@ -141,14 +159,14 @@
 				#size-cells = <0>;
 				port@0 {
 					reg = <0>;
-					typec0_con_hs: endpoint {
-						remote-endpoint = <&typec0_usb_hs>;
+					typec0_connector_hs: endpoint {
+						remote-endpoint = <&dwc3_0_hs>;
 					};
 				};
 				port@1 {
 					reg = <1>;
-					typec0_con_ss: endpoint {
-						remote-endpoint = <&typec0_usb_ss>;
+					typec0_connector_ss: endpoint {
+						remote-endpoint = <&atcphy0_typec_lanes>;
 					};
 				};
 			};
@@ -173,14 +191,14 @@
 				#size-cells = <0>;
 				port@0 {
 					reg = <0>;
-					typec1_con_hs: endpoint {
-						remote-endpoint = <&typec1_usb_hs>;
+					typec1_connector_hs: endpoint {
+						remote-endpoint = <&dwc3_1_hs>;
 					};
 				};
 				port@1 {
 					reg = <1>;
-					typec1_con_ss: endpoint {
-						remote-endpoint = <&typec1_usb_ss>;
+					typec1_connector_ss: endpoint {
+						remote-endpoint = <&atcphy1_typec_lanes>;
 					};
 				};
 			};
@@ -205,14 +223,14 @@
 				#size-cells = <0>;
 				port@0 {
 					reg = <0>;
-					typec2_con_hs: endpoint {
-						remote-endpoint = <&typec2_usb_hs>;
+					typec2_connector_hs: endpoint {
+						remote-endpoint = <&dwc3_2_hs>;
 					};
 				};
 				port@1 {
 					reg = <1>;
-					typec2_con_ss: endpoint {
-						remote-endpoint = <&typec2_usb_ss>;
+					typec2_connector_ss: endpoint {
+						remote-endpoint = <&atcphy2_typec_lanes>;
 					};
 				};
 			};
@@ -369,7 +387,7 @@
 		apple,antenna-sku = "XX";
 	};
 
-	bluetooth0: network@0,1 {
+	bluetooth0: bluetooth@0,1 {
 		compatible = "pci14e4,5f71";
 		reg = <0x10100 0x0 0x0 0x0 0x0>;
 		/* To be filled by the loader */
@@ -400,52 +418,74 @@
 
 /* USB controllers */
 &dwc3_0 {
-	port {
-		typec0_usb_hs: endpoint {
-			remote-endpoint = <&typec0_con_hs>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			dwc3_0_hs: endpoint {
+				remote-endpoint = <&typec0_connector_hs>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			dwc3_0_ss: endpoint {
+				remote-endpoint = <&atcphy0_usb3>;
+			};
 		};
 	};
 };
 
 &dwc3_1 {
-	port {
-		typec1_usb_hs: endpoint {
-			remote-endpoint = <&typec1_con_hs>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			dwc3_1_hs: endpoint {
+				remote-endpoint = <&typec1_connector_hs>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			dwc3_1_ss: endpoint {
+				remote-endpoint = <&atcphy1_usb3>;
+			};
 		};
 	};
 };
 
 &dwc3_2 {
-	port {
-		typec2_usb_hs: endpoint {
-			remote-endpoint = <&typec2_con_hs>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			dwc3_2_hs: endpoint {
+				remote-endpoint = <&typec2_connector_hs>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			dwc3_2_ss: endpoint {
+				remote-endpoint = <&atcphy2_usb3>;
+			};
 		};
 	};
 };
 
-/* Type-C PHYs */
-&atcphy0 {
-	port {
-		typec0_usb_ss: endpoint {
-			remote-endpoint = <&typec0_con_ss>;
-		};
-	};
-};
-
-&atcphy1 {
-	port {
-		typec1_usb_ss: endpoint {
-			remote-endpoint = <&typec1_con_ss>;
-		};
-	};
-};
-
-&atcphy2 {
-	port {
-		typec2_usb_ss: endpoint {
-			remote-endpoint = <&typec2_con_ss>;
-		};
-	};
+/*
+ * ps_atc3_usb_aon power-domain is always-on to keep dwc3 working over suspend.
+ * atc3 is used exclusively for the DP-to-HDMI so do not keep this always on.
+ */
+&ps_atc3_usb_aon {
+	/delete-property/ apple,always-on;
 };
 
 /* ATC3 is used for DisplayPort -> HDMI only */
@@ -460,13 +500,104 @@
 &dwc3_3 {
 	status = "disabled";
 };
+
 /* Delete unused dwc3_3 to prevent dt_disable_missing_devs() from disabling
  * atcphy3 via phandle references from a disablecd device.
  */
 /delete-node/ &dwc3_3;
 
-&ps_atc3_usb_aon {
-	/delete-property/ apple,always-on;
+/* Type-C PHYs */
+&atcphy0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			atcphy0_typec_lanes: endpoint {
+				remote-endpoint = <&typec0_connector_ss>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			atcphy0_usb3: endpoint {
+				remote-endpoint = <&dwc3_0_ss>;
+			};
+		};
+	};
+};
+
+&atcphy1 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			atcphy1_typec_lanes: endpoint {
+				remote-endpoint = <&typec1_connector_ss>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			atcphy1_usb3: endpoint {
+				remote-endpoint = <&dwc3_1_ss>;
+			};
+		};
+	};
+};
+
+&atcphy2 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			atcphy2_typec_lanes: endpoint {
+				remote-endpoint = <&typec2_connector_ss>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			atcphy2_usb3: endpoint {
+				remote-endpoint = <&dwc3_2_ss>;
+			};
+		};
+	};
+};
+
+&atcphy3 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@2 {
+			reg = <2>;
+			atcphy3_dp: endpoint {
+				remote-endpoint = <&decpext0_dpout>;
+			};
+		};
+	};
+};
+
+&aop_mbox {
+       status = "okay";
+};
+
+&aop_dart {
+       status = "okay";
+};
+
+&aop_admac {
+       status = "okay";
+};
+
+&aop {
+       status = "okay";
 };
 
 / {
@@ -509,3 +640,7 @@
 &isp {
 	apple,platform-id = <3>;
 };
+
+#include "hwmon-common.dtsi"
+#include "hwmon-fan-dual.dtsi"
+#include "hwmon-laptop.dtsi"

--- a/arch/arm/dts/t600x-j375.dtsi
+++ b/arch/arm/dts/t600x-j375.dtsi
@@ -10,6 +10,8 @@
  */
 
 / {
+	chassis-type = "desktop";
+
 	aliases {
 		atcphy0 = &atcphy0;
 		atcphy1 = &atcphy1;
@@ -22,8 +24,8 @@
 		disp0_piodma = &disp0_piodma;
 		#endif
 		ethernet0 = &ethernet0;
-		nvram = &nvram;
 		serial0 = &serial0;
+		sio = &sio;
 		wifi0 = &wifi0;
 	};
 
@@ -43,13 +45,6 @@
 		};
 	};
 
-	reserved-memory {
-		#address-cells = <2>;
-		#size-cells = <2>;
-		ranges;
-		/* To be filled by loader */
-	};
-
 	memory@10000000000 {
 		device_type = "memory";
 		reg = <0x100 0 0x2 0>; /* To be filled by loader */
@@ -62,6 +57,11 @@
 
 &dcp {
 	apple,connector-type = "HDMI-A";
+};
+
+/* remove once m1n1 enables sio nodes after setup */
+&sio {
+        status = "okay";
 };
 
 /* USB Type C */
@@ -84,14 +84,14 @@
 				#size-cells = <0>;
 				port@0 {
 					reg = <0>;
-					typec0_con_hs: endpoint {
-						remote-endpoint = <&typec0_usb_hs>;
+					typec0_connector_hs: endpoint {
+						remote-endpoint = <&dwc3_0_hs>;
 					};
 				};
 				port@1 {
 					reg = <1>;
-					typec0_con_ss: endpoint {
-						remote-endpoint = <&typec0_usb_ss>;
+					typec0_connector_ss: endpoint {
+						remote-endpoint = <&atcphy0_typec_lanes>;
 					};
 				};
 			};
@@ -116,14 +116,14 @@
 				#size-cells = <0>;
 				port@0 {
 					reg = <0>;
-					typec1_con_hs: endpoint {
-						remote-endpoint = <&typec1_usb_hs>;
+					typec1_connector_hs: endpoint {
+						remote-endpoint = <&dwc3_1_hs>;
 					};
 				};
 				port@1 {
 					reg = <1>;
-					typec1_con_ss: endpoint {
-						remote-endpoint = <&typec1_usb_ss>;
+					typec1_connector_ss: endpoint {
+						remote-endpoint = <&atcphy1_typec_lanes>;
 					};
 				};
 			};
@@ -148,14 +148,14 @@
 				#size-cells = <0>;
 				port@0 {
 					reg = <0>;
-					typec2_con_hs: endpoint {
-						remote-endpoint = <&typec2_usb_hs>;
+					typec2_connector_hs: endpoint {
+						remote-endpoint = <&dwc3_2_hs>;
 					};
 				};
 				port@1 {
 					reg = <1>;
-					typec2_con_ss: endpoint {
-						remote-endpoint = <&typec2_usb_ss>;
+					typec2_connector_ss: endpoint {
+						remote-endpoint = <&atcphy2_typec_lanes>;
 					};
 				};
 			};
@@ -180,14 +180,14 @@
 				#size-cells = <0>;
 				port@0 {
 					reg = <0>;
-					typec3_con_hs: endpoint {
-						remote-endpoint = <&typec3_usb_hs>;
+					typec3_connector_hs: endpoint {
+						remote-endpoint = <&dwc3_3_hs>;
 					};
 				};
 				port@1 {
 					reg = <1>;
-					typec3_con_ss: endpoint {
-						remote-endpoint = <&typec3_usb_ss>;
+					typec3_connector_ss: endpoint {
+						remote-endpoint = <&atcphy3_typec_lanes>;
 					};
 				};
 			};
@@ -197,66 +197,170 @@
 
 /* USB controllers */
 &dwc3_0 {
-	port {
-		typec0_usb_hs: endpoint {
-			remote-endpoint = <&typec0_con_hs>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			dwc3_0_hs: endpoint {
+				remote-endpoint = <&typec0_connector_hs>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			dwc3_0_ss: endpoint {
+				remote-endpoint = <&atcphy0_usb3>;
+			};
 		};
 	};
 };
 
 &dwc3_1 {
-	port {
-		typec1_usb_hs: endpoint {
-			remote-endpoint = <&typec1_con_hs>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			dwc3_1_hs: endpoint {
+				remote-endpoint = <&typec1_connector_hs>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			dwc3_1_ss: endpoint {
+				remote-endpoint = <&atcphy1_usb3>;
+			};
 		};
 	};
 };
 
 &dwc3_2 {
-	port {
-		typec2_usb_hs: endpoint {
-			remote-endpoint = <&typec2_con_hs>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			dwc3_2_hs: endpoint {
+				remote-endpoint = <&typec2_connector_hs>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			dwc3_2_ss: endpoint {
+				remote-endpoint = <&atcphy2_usb3>;
+			};
 		};
 	};
 };
 
 &dwc3_3 {
-	port {
-		typec3_usb_hs: endpoint {
-			remote-endpoint = <&typec3_con_hs>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			dwc3_3_hs: endpoint {
+				remote-endpoint = <&typec3_connector_hs>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			dwc3_3_ss: endpoint {
+				remote-endpoint = <&atcphy3_usb3>;
+			};
 		};
 	};
 };
 
 /* Type-C PHYs */
 &atcphy0 {
-	port {
-		typec0_usb_ss: endpoint {
-			remote-endpoint = <&typec0_con_ss>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			atcphy0_typec_lanes: endpoint {
+				remote-endpoint = <&typec0_connector_ss>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			atcphy0_usb3: endpoint {
+				remote-endpoint = <&dwc3_0_ss>;
+			};
 		};
 	};
 };
 
 &atcphy1 {
-	port {
-		typec1_usb_ss: endpoint {
-			remote-endpoint = <&typec1_con_ss>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			atcphy1_typec_lanes: endpoint {
+				remote-endpoint = <&typec1_connector_ss>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			atcphy1_usb3: endpoint {
+				remote-endpoint = <&dwc3_1_ss>;
+			};
 		};
 	};
 };
 
 &atcphy2 {
-	port {
-		typec2_usb_ss: endpoint {
-			remote-endpoint = <&typec2_con_ss>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			atcphy2_typec_lanes: endpoint {
+				remote-endpoint = <&typec2_connector_ss>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			atcphy2_usb3: endpoint {
+				remote-endpoint = <&dwc3_2_ss>;
+			};
 		};
 	};
 };
 
 &atcphy3 {
-	port {
-		typec3_usb_ss: endpoint {
-			remote-endpoint = <&typec3_con_ss>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			atcphy3_typec_lanes: endpoint {
+				remote-endpoint = <&typec3_connector_ss>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			atcphy3_usb3: endpoint {
+				remote-endpoint = <&dwc3_3_ss>;
+			};
 		};
 	};
 };
@@ -327,24 +431,21 @@
 	bus-range = <1 1>;
 	pwren-gpios = <&smc_gpio 13 GPIO_ACTIVE_HIGH>;
 	wifi0: wifi@0,0 {
-		reg = <0x10000 0x0 0x0 0x0 0x0>;
 		compatible = "pci14e4,4433";
-		brcm,board-type = "apple,okinawa";
-		apple,antenna-sku = "XX";
+		reg = <0x10000 0x0 0x0 0x0 0x0>;
 		/* To be filled by the loader */
 		local-mac-address = [00 10 18 00 00 10];
+		apple,antenna-sku = "XX";
 	};
 
-	bluetooth0: network@0,1 {
+	bluetooth0: bluetooth@0,1 {
 		compatible = "pci14e4,5f71";
-		brcm,board-type = "apple,okinawa";
 		reg = <0x10100 0x0 0x0 0x0 0x0>;
 		/* To be filled by the loader */
 		local-bd-address = [00 00 00 00 00 00];
 	};
 };
 
-#ifndef NO_PCIE_SDHC
 &port01 {
 	/* SD card reader */
 	bus-range = <2 2>;
@@ -356,7 +457,6 @@
 		wp-inverted;
 	};
 };
-#endif
 
 &port02 {
 	/* 10 Gbit Ethernet */
@@ -385,15 +485,6 @@
 	status = "okay";
 };
 
-#ifndef NO_GPU
-&gpu {
-	apple,avg-power-ki-only = <0.6375>;
-	apple,avg-power-kp = <0.58>;
-	apple,avg-power-target-filter-tc = <1>;
-	apple,perf-base-pstate = <3>;
-	apple,ppm-ki = <5.8>;
-	apple,ppm-kp = <0.355>;
-};
-#endif
-
 #include "spi1-nvram.dtsi"
+
+#include "hwmon-common.dtsi"

--- a/arch/arm/dts/t600x-pmgr.dtsi
+++ b/arch/arm/dts/t600x-pmgr.dtsi
@@ -826,7 +826,7 @@
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
 		label = DIE_LABEL(sio_cpu);
-		power-domains = <&DIE_NODE(ps_sio)>;
+		power-domains = <&DIE_NODE(ps_sio) &DIE_NODE(ps_uart_p) &DIE_NODE(ps_spi_p) &DIE_NODE(ps_audio_p)>;
 	};
 
 	DIE_NODE(ps_fpwm0): power-controller@190 {
@@ -1469,7 +1469,7 @@
 		reg = <0x4000 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
-		label = "isp_set0";
+		label = DIE_LABEL(isp_set0);
 	};
 
 	DIE_NODE(ps_isp_set1): power-controller@4010 {
@@ -1477,7 +1477,7 @@
 		reg = <0x4010 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
-		label = "isp_set1";
+		label = DIE_LABEL(isp_set1);
 	};
 
 	DIE_NODE(ps_isp_fe): power-controller@4008 {
@@ -1485,7 +1485,7 @@
 		reg = <0x4008 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
-		label = "isp_set2";
+		label = DIE_LABEL(ps_isp_fe);
 	};
 
 	DIE_NODE(ps_isp_set3): power-controller@4028 {
@@ -1493,7 +1493,7 @@
 		reg = <0x4028 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
-		label = "isp_set3";
+		label = DIE_LABEL(isp_set3);
 	};
 
 	DIE_NODE(ps_isp_set4): power-controller@4020 {
@@ -1501,7 +1501,7 @@
 		reg = <0x4020 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
-		label = "isp_set4";
+		label = DIE_LABEL(isp_set4);
 	};
 
 	DIE_NODE(ps_isp_set5): power-controller@4030 {
@@ -1509,7 +1509,7 @@
 		reg = <0x4030 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
-		label = "isp_set5";
+		label = DIE_LABEL(isp_set5);
 	};
 
 	DIE_NODE(ps_isp_set6): power-controller@4018 {
@@ -1517,7 +1517,7 @@
 		reg = <0x4018 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
-		label = "isp_set6";
+		label = DIE_LABEL(isp_set6);
 	};
 
 	DIE_NODE(ps_isp_set7): power-controller@4038 {
@@ -1525,7 +1525,7 @@
 		reg = <0x4038 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
-		label = "isp_set7";
+		label = DIE_LABEL(isp_set7);
 	};
 
 	DIE_NODE(ps_isp_set8): power-controller@4040 {
@@ -1533,7 +1533,7 @@
 		reg = <0x4040 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
-		label = "isp_set8";
+		label = DIE_LABEL(isp_set8);
 	};
 };
 

--- a/arch/arm/dts/t6020-j414s.dts
+++ b/arch/arm/dts/t6020-j414s.dts
@@ -32,6 +32,11 @@
 	adj-height-mm = <189>;
 };
 
+&aop_audio {
+	apple,chassis-name = "J414";
+	apple,machine-kind = "MacBook Pro";
+};
+
 &sound {
 	compatible = "apple,j414-macaudio", "apple,j314-macaudio", "apple,macaudio";
 	model = "MacBook Pro J414";

--- a/arch/arm/dts/t6020-j416s.dts
+++ b/arch/arm/dts/t6020-j416s.dts
@@ -32,6 +32,11 @@
 	adj-height-mm = <216>;
 };
 
+&aop_audio {
+	apple,chassis-name = "J416";
+	apple,machine-kind = "MacBook Pro";
+};
+
 &sound {
 	compatible = "apple,j416-macaudio", "apple,j316-macaudio", "apple,macaudio";
 	model = "MacBook Pro J416";

--- a/arch/arm/dts/t6020-j474s.dts
+++ b/arch/arm/dts/t6020-j474s.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0+ OR MIT
 /*
- * Mac Mini (M2 Pro, 2023)
+ * Mac mini (M2 Pro, 2023)
  *
  * target-type: J474s
  *
@@ -11,14 +11,19 @@
 
 #include "t6020.dtsi"
 
-#define NO_PCIE_SDHC
+/*
+ * This model is very similar to M1 and M2 Mac Studio models so base it on those
+ * and remove the missing SDHCI controller.
+ */
+
 #include "t602x-j474-j475.dtsi"
 
 / {
 	compatible = "apple,j474s", "apple,t6020", "apple,arm-platform";
-	model = "Apple Mac Mini (M2 Pro, 2023)";
+	model = "Apple Mac mini (M2 Pro, 2023)";
 };
 
+/* PCIe devices */
 &wifi0 {
 	compatible = "pci14e4,4434";
 	brcm,board-type = "apple,tasmania";
@@ -29,15 +34,28 @@
 	brcm,board-type = "apple,tasmania";
 };
 
-/* PCIe devices */
-&port01 {
-	/*
-	 * TODO: do not enable port without device. This works around a Linux
-	 * bug which results in mismatched iommus on gaps in PCI(e) ports / bus
-	 * numbers.
-	 */
+/*
+ * port01 is unused, remove the PCIe sdhci0 node from t600x-j375.dtsi and adjust
+ * the iommu-map.
+ */
+/delete-node/ &sdhci0;
+
+&pcie0 {
+	iommu-map = <0x100 &pcie0_dart_0 1 1>,
+			<0x200 &pcie0_dart_2 1 1>,
+			<0x300 &pcie0_dart_3 1 1>;
+};
+
+&port02 {
 	bus-range = <2 2>;
-	status = "okay";
+};
+
+&ethernet0 {
+	reg = <0x20000 0x0 0x0 0x0 0x0>;
+};
+
+&port03 {
+	bus-range = <3 3>;
 };
 
 &sound {
@@ -78,8 +96,14 @@
 &dcpext0_mbox {
 	status = "okay";
 };
+&dpaudio1 {
+	status = "okay";
+};
 &dcpext0 {
 #else
+&dpaudio0 {
+	status = "okay";
+};
 &dcp {
 #endif
 	status = "okay";
@@ -100,3 +124,5 @@
 	/* Apple does not do this, but they probably should */
 	apple,perf-base-pstate = <3>;
 };
+
+#include "hwmon-mini.dtsi"

--- a/arch/arm/dts/t6020.dtsi
+++ b/arch/arm/dts/t6020.dtsi
@@ -20,7 +20,7 @@
 /delete-node/ &pmgr_south;
 
 &gpu {
-	compatible = "apple,agx-t6020", "apple,agx-g14x";
+	compatible = "apple,agx-t6020", "apple,agx-g14x", "apple,agx-g14s";
 
 	apple,avg-power-filter-tc-ms = <302>;
 	apple,avg-power-ki-only = <2.6375>;

--- a/arch/arm/dts/t6021-j414c.dts
+++ b/arch/arm/dts/t6021-j414c.dts
@@ -32,6 +32,11 @@
 	adj-height-mm = <189>;
 };
 
+&aop_audio {
+	apple,chassis-name = "J414";
+	apple,machine-kind = "MacBook Pro";
+};
+
 &sound {
 	compatible = "apple,j414-macaudio", "apple,j314-macaudio", "apple,macaudio";
 	model = "MacBook Pro J414";

--- a/arch/arm/dts/t6021-j416c.dts
+++ b/arch/arm/dts/t6021-j416c.dts
@@ -52,6 +52,11 @@
 	adj-height-mm = <216>;
 };
 
+&aop_audio {
+	apple,chassis-name = "J416";
+	apple,machine-kind = "MacBook Pro";
+};
+
 &sound {
 	compatible = "apple,j416-macaudio", "apple,j316-macaudio", "apple,macaudio";
 	model = "MacBook Pro J416";

--- a/arch/arm/dts/t6021-j475c.dts
+++ b/arch/arm/dts/t6021-j475c.dts
@@ -27,6 +27,16 @@
 	brcm,board-type = "apple,canary";
 };
 
+/* enable PCIe port01 with SDHCI */
+&port01 {
+	pwren-gpios = <&smc_gpio 22 GPIO_ACTIVE_HIGH>;
+	status = "okay";
+};
+
+&pcie0_dart_1 {
+	status = "okay";
+};
+
 &pinctrl_ap {
 	usb_hub_oe-hog {
 		gpio-hog;
@@ -82,8 +92,14 @@
 &dcpext0_mbox {
 	status = "okay";
 };
+&dpaudio1 {
+	status = "okay";
+};
 &dcpext0 {
 #else
+&dpaudio0 {
+	status = "okay";
+};
 &dcp {
 #endif
 	status = "okay";
@@ -99,3 +115,13 @@
 	phy-names = "dp-phy";
 	apple,dptx-phy = <4>;
 };
+
+&gpu {
+	apple,idleoff-standby-timer = <3000>;
+	apple,perf-base-pstate = <5>;
+	apple,perf-boost-ce-step = <100>;
+	apple,perf-boost-min-util = <75>;
+	apple,perf-tgt-utilization = <70>;
+};
+
+#include "hwmon-fan-dual.dtsi"

--- a/arch/arm/dts/t6021.dtsi
+++ b/arch/arm/dts/t6021.dtsi
@@ -26,7 +26,7 @@
 #include "t602x-common.dtsi"
 
 / {
-	compatible = "apple,t6001", "apple,arm-platform";
+	compatible = "apple,t6021", "apple,arm-platform";
 
 	soc {
 		compatible = "simple-bus";
@@ -74,7 +74,7 @@
 };
 
 &gpu {
-	compatible = "apple,agx-t6021", "apple,agx-g14x";
+	compatible = "apple,agx-t6021", "apple,agx-g14x", "apple,agx-g14c", "apple,agx-g14s";
 
 	apple,avg-power-filter-tc-ms = <300>;
 	apple,avg-power-ki-only = <1.5125>;

--- a/arch/arm/dts/t6022-j180d.dts
+++ b/arch/arm/dts/t6022-j180d.dts
@@ -11,10 +11,13 @@
 
 #include "t6022.dtsi"
 #include "t6022-jxxxd.dtsi"
+#include "t6022-pcie-ge.dtsi"
 
 / {
 	compatible = "apple,j180d", "apple,t6022", "apple,arm-platform";
 	model = "Apple Mac Pro (M2 Ultra, 2023)";
+	chassis-type = "server";
+
 	aliases {
 		atcphy0 = &atcphy0;
 		atcphy1 = &atcphy1;
@@ -24,12 +27,12 @@
 		atcphy5 = &atcphy1_die1;
 		atcphy6 = &atcphy2_die1;
 		atcphy7 = &atcphy3_die1;
-		//bluetooth0 = &bluetooth0;
-		//ethernet0 = &ethernet0;
-		//ethernet1 = &ethernet1;
-		nvram = &nvram;
+		bluetooth0 = &bluetooth0;
+		dcpext0 = &dcpext0;
+		ethernet0 = &ethernet0;
+		ethernet1 = &ethernet1;
 		serial0 = &serial0;
-		//wifi0 = &wifi0;
+		wifi0 = &wifi0;
 	};
 
 	chosen {
@@ -65,6 +68,46 @@
 	status = "okay";
 };
 
+&lpdptxphy {
+	status = "okay";
+};
+
+&display {
+	iommus = <&dispext0_dart_die1 0>, <&dispext0_dart 0>;
+};
+
+&dispext0_dart {
+	status = "okay";
+};
+
+&dcpext0_dart {
+	status = "okay";
+};
+
+&dcpext0_mbox {
+	status = "okay";
+};
+
+&dcpext0 {
+	status = "okay";
+	apple,connector-type = "HDMI-A";
+
+	/*  HDMI HPD gpio, used as interrupt*/
+	hdmi-hpd-gpios = <&pinctrl_aop 25 GPIO_ACTIVE_HIGH>;
+
+	// shared between dp2hdmi-gpio0 / dp2hdmi-gpio1
+	// hdmi-pwren-gpios = <&smc_gpio 23 GPIO_ACTIVE_HIGH>;
+
+	phys = <&lpdptxphy>;
+	phy-names = "dp-phy";
+	apple,dptx-phy = <4>;
+	apple,dptx-die = <0>;
+};
+
+&dpaudio1 {
+	status = "okay";
+};
+
 /* USB Type C Rear */
 &i2c0 {
 	hpm2: usb-pd@3b {
@@ -85,14 +128,14 @@
 				#size-cells = <0>;
 				port@0 {
 					reg = <0>;
-					typec2_con_hs: endpoint {
-						remote-endpoint = <&typec2_usb_hs>;
+					typec2_connector_hs: endpoint {
+						remote-endpoint = <&dwc3_2_hs>;
 					};
 				};
 				port@1 {
 					reg = <1>;
-					typec2_con_ss: endpoint {
-						remote-endpoint = <&typec2_usb_ss>;
+					typec2_connector_ss: endpoint {
+						remote-endpoint = <&atcphy2_typec_lanes>;
 					};
 				};
 			};
@@ -117,23 +160,21 @@
 				#size-cells = <0>;
 				port@0 {
 					reg = <0>;
-					typec3_con_hs: endpoint {
-						remote-endpoint = <&typec3_usb_hs>;
+					typec3_connector_hs: endpoint {
+						remote-endpoint = <&dwc3_3_hs>;
 					};
 				};
 				port@1 {
 					reg = <1>;
-					typec3_con_ss: endpoint {
-						remote-endpoint = <&typec3_usb_ss>;
+					typec3_connector_ss: endpoint {
+						remote-endpoint = <&atcphy3_typec_lanes>;
 					};
 				};
 			};
 		};
 	};
 
-	/* hpm4 included from t6022-jxxxd.dtsi */
-
-	/* hpm5 included from t6022-jxxxd.dtsi */
+	/* hpm4 and hpm5 included from t6022-jxxxd.dtsi */
 
 	hpm6: usb-pd@3d {
 		compatible = "apple,cd321x";
@@ -153,14 +194,14 @@
 				#size-cells = <0>;
 				port@0 {
 					reg = <0>;
-					typec6_con_hs: endpoint {
-						remote-endpoint = <&typec6_usb_hs>;
+					typec6_connector_hs: endpoint {
+						remote-endpoint = <&dwc3_6_hs>;
 					};
 				};
 				port@1 {
 					reg = <1>;
-					typec6_con_ss: endpoint {
-						remote-endpoint = <&typec6_usb_ss>;
+					typec6_connector_ss: endpoint {
+						remote-endpoint = <&atcphy6_typec_lanes>;
 					};
 				};
 			};
@@ -185,14 +226,14 @@
 				#size-cells = <0>;
 				port@0 {
 					reg = <0>;
-					typec7_con_hs: endpoint {
-						remote-endpoint = <&typec7_usb_hs>;
+					typec7_connector_hs: endpoint {
+						remote-endpoint = <&dwc3_7_hs>;
 					};
 				};
 				port@1 {
 					reg = <1>;
-					typec7_con_ss: endpoint {
-						remote-endpoint = <&typec7_usb_ss>;
+					typec7_connector_ss: endpoint {
+						remote-endpoint = <&atcphy7_typec_lanes>;
 					};
 				};
 			};
@@ -200,11 +241,11 @@
 	};
 };
 
-&hpm4 {
+&typec4 {
 	label = "USB-C Back 3";
 };
 
-&hpm5 {
+&typec5 {
 	label = "USB-C Back 4";
 };
 
@@ -230,14 +271,14 @@
 				#size-cells = <0>;
 				port@0 {
 					reg = <0>;
-					typec0_con_hs: endpoint {
-						remote-endpoint = <&typec0_usb_hs>;
+					typec0_connector_hs: endpoint {
+						remote-endpoint = <&dwc3_0_hs>;
 					};
 				};
 				port@1 {
 					reg = <1>;
-					typec0_con_ss: endpoint {
-						remote-endpoint = <&typec0_usb_ss>;
+					typec0_connector_ss: endpoint {
+						remote-endpoint = <&atcphy0_typec_lanes>;
 					};
 				};
 			};
@@ -262,14 +303,14 @@
 				#size-cells = <0>;
 				port@0 {
 					reg = <0>;
-					typec1_con_hs: endpoint {
-						remote-endpoint = <&typec1_usb_hs>;
+					typec1_connector_hs: endpoint {
+						remote-endpoint = <&dwc3_1_hs>;
 					};
 				};
 				port@1 {
 					reg = <1>;
-					typec1_con_ss: endpoint {
-						remote-endpoint = <&typec1_usb_ss>;
+					typec1_connector_ss: endpoint {
+						remote-endpoint = <&atcphy1_typec_lanes>;
 					};
 				};
 			};
@@ -279,98 +320,255 @@
 
 /* USB controllers */
 &dwc3_0 {
-	port {
-		typec0_usb_hs: endpoint {
-			remote-endpoint = <&typec0_con_hs>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			dwc3_0_hs: endpoint {
+				remote-endpoint = <&typec0_connector_hs>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			dwc3_0_ss: endpoint {
+				remote-endpoint = <&atcphy0_usb3>;
+			};
 		};
 	};
 };
 
 &dwc3_1 {
-	port {
-		typec1_usb_hs: endpoint {
-			remote-endpoint = <&typec1_con_hs>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			dwc3_1_hs: endpoint {
+				remote-endpoint = <&typec1_connector_hs>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			dwc3_1_ss: endpoint {
+				remote-endpoint = <&atcphy1_usb3>;
+			};
 		};
 	};
 };
 
 &dwc3_2 {
-	port {
-		typec2_usb_hs: endpoint {
-			remote-endpoint = <&typec2_con_hs>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			dwc3_2_hs: endpoint {
+				remote-endpoint = <&typec2_connector_hs>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			dwc3_2_ss: endpoint {
+				remote-endpoint = <&atcphy2_usb3>;
+			};
 		};
 	};
 };
 
 &dwc3_3 {
-	port {
-		typec3_usb_hs: endpoint {
-			remote-endpoint = <&typec3_con_hs>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			dwc3_3_hs: endpoint {
+				remote-endpoint = <&typec3_connector_hs>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			dwc3_3_ss: endpoint {
+				remote-endpoint = <&atcphy3_usb3>;
+			};
 		};
 	};
 };
 
+/* USB controllers on die 1 */
 &dwc3_2_die1 {
-	port {
-		typec6_usb_hs: endpoint {
-			remote-endpoint = <&typec6_con_hs>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			dwc3_6_hs: endpoint {
+				remote-endpoint = <&typec6_connector_hs>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			dwc3_6_ss: endpoint {
+				remote-endpoint = <&atcphy6_usb3>;
+			};
 		};
 	};
 };
 
 &dwc3_3_die1 {
-	port {
-		typec7_usb_hs: endpoint {
-			remote-endpoint = <&typec7_con_hs>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			dwc3_7_hs: endpoint {
+				remote-endpoint = <&typec7_connector_hs>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			dwc3_7_ss: endpoint {
+				remote-endpoint = <&atcphy7_usb3>;
+			};
 		};
 	};
 };
 
 /* Type-C PHYs */
 &atcphy0 {
-	port {
-		typec0_usb_ss: endpoint {
-			remote-endpoint = <&typec0_con_ss>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			atcphy0_typec_lanes: endpoint {
+				remote-endpoint = <&typec0_connector_ss>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			atcphy0_usb3: endpoint {
+				remote-endpoint = <&dwc3_0_ss>;
+			};
 		};
 	};
 };
 
 &atcphy1 {
-	port {
-		typec1_usb_ss: endpoint {
-			remote-endpoint = <&typec1_con_ss>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			atcphy1_typec_lanes: endpoint {
+				remote-endpoint = <&typec1_connector_ss>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			atcphy1_usb3: endpoint {
+				remote-endpoint = <&dwc3_1_ss>;
+			};
 		};
 	};
 };
 
 &atcphy2 {
-	port {
-		typec2_usb_ss: endpoint {
-			remote-endpoint = <&typec2_con_ss>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			atcphy2_typec_lanes: endpoint {
+				remote-endpoint = <&typec2_connector_ss>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			atcphy2_usb3: endpoint {
+				remote-endpoint = <&dwc3_2_ss>;
+			};
 		};
 	};
 };
 
 &atcphy3 {
-	port {
-		typec3_usb_ss: endpoint {
-			remote-endpoint = <&typec3_con_ss>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			atcphy3_typec_lanes: endpoint {
+				remote-endpoint = <&typec3_connector_ss>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			atcphy3_usb3: endpoint {
+				remote-endpoint = <&dwc3_3_ss>;
+			};
 		};
 	};
 };
 
 &atcphy2_die1 {
-	port {
-		typec6_usb_ss: endpoint {
-			remote-endpoint = <&typec6_con_ss>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			atcphy6_typec_lanes: endpoint {
+				remote-endpoint = <&typec6_connector_ss>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			atcphy6_usb3: endpoint {
+				remote-endpoint = <&dwc3_6_ss>;
+			};
 		};
 	};
 };
 
 &atcphy3_die1 {
-	port {
-		typec7_usb_ss: endpoint {
-			remote-endpoint = <&typec7_con_ss>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			atcphy7_typec_lanes: endpoint {
+				remote-endpoint = <&typec7_connector_ss>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			atcphy7_usb3: endpoint {
+				remote-endpoint = <&dwc3_7_ss>;
+			};
 		};
 	};
 };
@@ -455,12 +653,331 @@
 	};
 };
 
-&pcie0 {
-	status = "disabled";
+/* PCIe devices */
+&port_ge00 {
+	bus-range = <0x01 0x09>;
+
+	pci@0,0 {
+		// compatible = "pci11f8,4000", "pciclass,060400", "pciclass,0604";
+		device_type = "pci";
+		reg = <0x10000 0x00 0x00 0x00 0x00>;
+		bus-range = <0x02 0x07>;
+
+		#address-cells = <0x03>;
+		#size-cells = <0x02>;
+		ranges = <0x82010000 0x00 0x80000000 0x82010000 0x00 0x80000000 0x00 0x500000>,
+			 <0xc3010000 0x18 0x00000000 0xc3010000 0x18 0x00000000 0x00 0x500000>;
+
+		#interrupt-cells = <0x01>;
+		interrupt-map-mask = <0xffff00 0x00 0x00 0x07>;
+		interrupt-map = <0x20000 0x00 0x00 0x01 &port_ge00 0x00 0x00 0x00 0x00>,
+				<0x20000 0x00 0x00 0x02 &port_ge00 0x00 0x00 0x00 0x01>,
+				<0x20000 0x00 0x00 0x03 &port_ge00 0x00 0x00 0x00 0x02>,
+				<0x20000 0x00 0x00 0x04 &port_ge00 0x00 0x00 0x00 0x03>,
+				<0x20800 0x00 0x00 0x01 &port_ge00 0x00 0x00 0x00 0x01>,
+				<0x20800 0x00 0x00 0x02 &port_ge00 0x00 0x00 0x00 0x02>,
+				<0x20800 0x00 0x00 0x03 &port_ge00 0x00 0x00 0x00 0x03>,
+				<0x20800 0x00 0x00 0x04 &port_ge00 0x00 0x00 0x00 0x00>,
+				<0x21000 0x00 0x00 0x01 &port_ge00 0x00 0x00 0x00 0x02>,
+				<0x21000 0x00 0x00 0x02 &port_ge00 0x00 0x00 0x00 0x03>,
+				<0x21000 0x00 0x00 0x03 &port_ge00 0x00 0x00 0x00 0x00>,
+				<0x21000 0x00 0x00 0x04 &port_ge00 0x00 0x00 0x00 0x01>,
+				<0x21800 0x00 0x00 0x01 &port_ge00 0x00 0x00 0x00 0x03>,
+				<0x21800 0x00 0x00 0x02 &port_ge00 0x00 0x00 0x00 0x00>,
+				<0x21800 0x00 0x00 0x03 &port_ge00 0x00 0x00 0x00 0x01>,
+				<0x21800 0x00 0x00 0x04 &port_ge00 0x00 0x00 0x00 0x02>,
+				<0x22000 0x00 0x00 0x01 &port_ge00 0x00 0x00 0x00 0x00>,
+				<0x22000 0x00 0x00 0x02 &port_ge00 0x00 0x00 0x00 0x01>,
+				<0x22000 0x00 0x00 0x03 &port_ge00 0x00 0x00 0x00 0x02>,
+				<0x22000 0x00 0x00 0x04 &port_ge00 0x00 0x00 0x00 0x03>;
+
+		/* pci-slot1-dsp, PCIe slot-1 */
+		pci@0,0 {
+			compatible = "pci11f8,4000", "pciclass,060400", "pciclass,0604";
+			device_type = "pci";
+			reg = <0x20000 0x00 0x00 0x00 0x00>;
+			bus-range = <0x03 0x03>;
+
+			#address-cells = <0x03>;
+			#size-cells = <0x02>;
+			ranges;
+		};
+
+		/* pci-slot2-dsp, PCIe slot-2 */
+		pci@1,0 {
+			compatible = "pci11f8,4000", "pciclass,060400", "pciclass,0604";
+			device_type = "pci";
+			reg = <0x20800 0x00 0x00 0x00 0x00>;
+			bus-range = <0x04 0x04>;
+
+			#address-cells = <0x03>;
+			#size-cells = <0x02>;
+			ranges;
+		};
+
+		/* pci-slot3-dsp, PCIe slot-3 */
+		pci@2,0 {
+			compatible = "pci11f8,4000", "pciclass,060400", "pciclass,0604";
+			device_type = "pci";
+			reg = <0x21000 0x00 0x00 0x00 0x00>;
+			bus-range = <0x05 0x05>;
+
+			#address-cells = <0x03>;
+			#size-cells = <0x02>;
+			ranges;
+		};
+
+		/* pci-slot4-dsp, PCIe slot-4 */
+		pci@3,0 {
+			compatible = "pci11f8,4000", "pciclass,060400", "pciclass,0604";
+			device_type = "pci";
+			reg = <0x21800 0x00 0x00 0x00 0x00>;
+			bus-range = <0x06 0x06>;
+
+			#address-cells = <0x03>;
+			#size-cells = <0x02>;
+			ranges;
+		};
+
+		/* pci-slot5-dsp, PCIe slot-5 */
+		pci@4,0 {
+			compatible = "pci11f8,4000", "pciclass,060400", "pciclass,0604";
+			device_type = "pci";
+			reg = <0x22000 0x00 0x00 0x00 0x00>;
+			bus-range = <0x07 0x07>;
+
+			#address-cells = <0x03>;
+			#size-cells = <0x02>;
+			ranges;
+		};
+
+	};
 };
 
-&pcie0_dart_0 {
-	status = "disabled";
+&port_ge00_die1 {
+	bus-range = <0x01 0x09>;
+
+	/*
+	 * Add mulptiple "reset-gpios" since there is no mechanismen to access
+	 * PERST# for devices behind the PCIe switch.
+	 * The "pwren" GPIO is from the wifi/bt chip which faces the same
+	 * problem without pci-pwrctrl integration.
+	 */
+	reset-gpios = <&pinctrl_ap 4 GPIO_ACTIVE_LOW>,
+		<&pinctrl_ap 6 GPIO_ACTIVE_LOW>,
+		<&pinctrl_ap 7 GPIO_ACTIVE_LOW>,
+		<&pinctrl_ap_die1 9 GPIO_ACTIVE_LOW>;
+	pwren-gpios = <&smc_gpio 13 GPIO_ACTIVE_HIGH>;
+
+	pci@0,0 {
+		device_type = "pci";
+		reg = <0x10000 0x00 0x00 0x00 0x00>;
+		bus-range = <0x02 0x09>;
+
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-map-mask = <0xffff00 0x00 0x00 0x07>;
+		interrupt-map = <0x20000 0x00 0x00 0x01 &port_ge00_die1 0x00 0x00 0x00 0x00>,
+				<0x20000 0x00 0x00 0x02 &port_ge00_die1 0x00 0x00 0x00 0x01>,
+				<0x20000 0x00 0x00 0x03 &port_ge00_die1 0x00 0x00 0x00 0x02>,
+				<0x20000 0x00 0x00 0x04 &port_ge00_die1 0x00 0x00 0x00 0x03>,
+				<0x20800 0x00 0x00 0x01 &port_ge00_die1 0x00 0x00 0x00 0x01>,
+				<0x20800 0x00 0x00 0x02 &port_ge00_die1 0x00 0x00 0x00 0x02>,
+				<0x20800 0x00 0x00 0x03 &port_ge00_die1 0x00 0x00 0x00 0x03>,
+				<0x20800 0x00 0x00 0x04 &port_ge00_die1 0x00 0x00 0x00 0x00>,
+				<0x21000 0x00 0x00 0x01 &port_ge00_die1 0x00 0x00 0x00 0x02>,
+				<0x21000 0x00 0x00 0x02 &port_ge00_die1 0x00 0x00 0x00 0x03>,
+				<0x21000 0x00 0x00 0x03 &port_ge00_die1 0x00 0x00 0x00 0x00>,
+				<0x21000 0x00 0x00 0x04 &port_ge00_die1 0x00 0x00 0x00 0x01>,
+				<0x21800 0x00 0x00 0x01 &port_ge00_die1 0x00 0x00 0x00 0x03>,
+				<0x21800 0x00 0x00 0x02 &port_ge00_die1 0x00 0x00 0x00 0x00>,
+				<0x21800 0x00 0x00 0x03 &port_ge00_die1 0x00 0x00 0x00 0x01>,
+				<0x21800 0x00 0x00 0x04 &port_ge00_die1 0x00 0x00 0x00 0x02>,
+				<0x22000 0x00 0x00 0x01 &port_ge00_die1 0x00 0x00 0x00 0x00>,
+				<0x22000 0x00 0x00 0x02 &port_ge00_die1 0x00 0x00 0x00 0x01>,
+				<0x22000 0x00 0x00 0x03 &port_ge00_die1 0x00 0x00 0x00 0x02>,
+				<0x22000 0x00 0x00 0x04 &port_ge00_die1 0x00 0x00 0x00 0x03>,
+				<0x22800 0x00 0x00 0x01 &port_ge00_die1 0x00 0x00 0x00 0x01>,
+				<0x22800 0x00 0x00 0x02 &port_ge00_die1 0x00 0x00 0x00 0x02>,
+				<0x22800 0x00 0x00 0x03 &port_ge00_die1 0x00 0x00 0x00 0x03>,
+				<0x22800 0x00 0x00 0x04 &port_ge00_die1 0x00 0x00 0x00 0x00>,
+				<0x23000 0x00 0x00 0x01 &port_ge00_die1 0x00 0x00 0x00 0x02>,
+				<0x23000 0x00 0x00 0x02 &port_ge00_die1 0x00 0x00 0x00 0x03>,
+				<0x23000 0x00 0x00 0x03 &port_ge00_die1 0x00 0x00 0x00 0x00>,
+				<0x23000 0x00 0x00 0x04 &port_ge00_die1 0x00 0x00 0x00 0x01>;
+
+		/* pci-usba-dsp, internal USB-A port */
+		pci@0,0 {
+			compatible = "pci11f8,4000", "pciclass,060400", "pciclass,0604";
+			device_type = "pci";
+			reg = <0x20000 0x00 0x00 0x00 0x00>;
+			bus-range = <0x03 0x03>;
+
+			#address-cells = <3>;
+			#size-cells = <2>;
+			ranges;
+
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			interrupt-map-mask = <0 0 0 7>;
+			interrupt-map = <0x30000 0x00 0x00 0x02 &port_ge00_die1 0x00 0x00 0x00 0x00>,
+					<0x30000 0x00 0x00 0x03 &port_ge00_die1 0x00 0x00 0x00 0x01>,
+					<0x30000 0x00 0x00 0x04 &port_ge00_die1 0x00 0x00 0x00 0x02>;
+
+			/* temporarily handled in the root port */
+			// reset-gpios = <&pinctrl_ap 6 GPIO_ACTIVE_LOW>;
+		};
+
+		/* pci-sata-dsp, internal AHCI controller */
+		pci@1,0 {
+			compatible = "pci11f8,4000", "pciclass,060400", "pciclass,0604";
+			device_type = "pci";
+			reg = <0x20800 0x00 0x00 0x00 0x00>;
+			bus-range = <0x04 0x04>;
+
+			#address-cells = <3>;
+			#size-cells = <2>;
+			ranges;
+
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			interrupt-map-mask = <0 0 0 7>;
+			interrupt-map = <0x40000 0x00 0x00 0x01 &port_ge00_die1 0x00 0x00 0x00 0x00>,
+					<0x40000 0x00 0x00 0x02 &port_ge00_die1 0x00 0x00 0x00 0x01>,
+					<0x40000 0x00 0x00 0x03 &port_ge00_die1 0x00 0x00 0x00 0x02>;
+		};
+
+		/* pci-bio-dsp, I/O board USB-A ports */
+		pci@2,0 {
+			compatible = "pci11f8,4000", "pciclass,060400", "pciclass,0604";
+			device_type = "pci";
+			reg = <0x21000 0x00 0x00 0x00 0x00>;
+			bus-range = <0x05 0x05>;
+
+			#address-cells = <3>;
+			#size-cells = <2>;
+			ranges;
+
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			interrupt-map-mask = <0 0 0 7>;
+			interrupt-map = <0x50000 0x00 0x00 0x01 &port_ge00_die1 0x00 0x00 0x00 0x01>,
+					<0x50000 0x00 0x00 0x02 &port_ge00_die1 0x00 0x00 0x00 0x02>,
+					<0x50000 0x00 0x00 0x04 &port_ge00_die1 0x00 0x00 0x00 0x00>;
+
+			/* temporarily handled in the root port */
+			// reset-gpios = <&pinctrl_ap 7 GPIO_ACTIVE_LOW>;
+		};
+
+		/* pci-lan-dsp, Qtion AQC113 10G etherner controller (0) */
+		pci@3,0 {
+			compatible = "pci11f8,4000", "pciclass,060400", "pciclass,0604";
+			device_type = "pci";
+			reg = <0x21800 0x00 0x00 0x00 0x00>;
+			bus-range = <0x06 0x06>;
+
+			#address-cells = <3>;
+			#size-cells = <2>;
+			ranges;
+
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			interrupt-map-mask = <0 0 0 7>;
+			interrupt-map = <0x60000 0x00 0x00 0x01 &port_ge00_die1 0x00 0x00 0x00 0x02>,
+					<0x60000 0x00 0x00 0x03 &port_ge00_die1 0x00 0x00 0x00 0x00>,
+					<0x60000 0x00 0x00 0x04 &port_ge00_die1 0x00 0x00 0x00 0x01>;
+
+			ethernet0: ethernet@0,0 {
+				reg = <0x60000 0x0 0x0 0x0 0x0>;
+				/* To be filled by the loader */
+				local-mac-address = [00 10 18 00 00 00];
+			};
+		};
+
+		/* pci-lan-b-dsp, Qtion AQC113 10G etherner controller (1) */
+		pci@4,0 {
+			compatible = "pci11f8,4000", "pciclass,060400", "pciclass,0604";
+			device_type = "pci";
+			reg = <0x22000 0x00 0x00 0x00 0x00>;
+			bus-range = <0x07 0x07>;
+
+			#address-cells = <3>;
+			#size-cells = <2>;
+			ranges;
+
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			interrupt-map-mask = <0 0 0 7>;
+			interrupt-map = <0x70000 0x00 0x00 0x02 &port_ge00_die1 0x00 0x00 0x00 0x00>,
+					<0x70000 0x00 0x00 0x03 &port_ge00_die1 0x00 0x00 0x00 0x01>,
+					<0x70000 0x00 0x00 0x04 &port_ge00_die1 0x00 0x00 0x00 0x02>;
+
+			ethernet1: ethernet@0,0 {
+				reg = <0x70000 0x0 0x0 0x0 0x0>;
+				/* To be filled by the loader */
+				local-mac-address = [00 10 18 00 00 00];
+			};
+		};
+
+		/* pci-wifibt-dsp, Broadcom BCM4388 Wlan/BT */
+		pci@5,0 {
+			compatible = "pci11f8,4000", "pciclass,060400", "pciclass,0604";
+			device_type = "pci";
+			reg = <0x22800 0x00 0x00 0x00 0x00>;
+			bus-range = <0x08 0x08>;
+
+			#address-cells = <3>;
+			#size-cells = <2>;
+			ranges;
+
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			interrupt-map-mask = <0 0 0 7>;
+			interrupt-map = <0x80000 0x00 0x00 0x01 &port_ge00_die1 0x00 0x00 0x00 0x00>,
+					<0x80000 0x00 0x00 0x02 &port_ge00_die1 0x00 0x00 0x00 0x01>,
+					<0x80000 0x00 0x00 0x03 &port_ge00_die1 0x00 0x00 0x00 0x02>,
+					<0x80100 0x00 0x00 0x01 &port_ge00_die1 0x00 0x00 0x00 0x00>,
+					<0x80100 0x00 0x00 0x02 &port_ge00_die1 0x00 0x00 0x00 0x01>,
+					<0x80100 0x00 0x00 0x03 &port_ge00_die1 0x00 0x00 0x00 0x02>;
+
+			/* temporarily handled in the root port */
+			// reset-gpios = <&pinctrl_ap 4 GPIO_ACTIVE_LOW>;
+			// pwren-gpios = <&smc_gpio 13 GPIO_ACTIVE_HIGH>;
+
+			wifi0: wifi@0,0 {
+				reg = <0x80000 0x0 0x0 0x0 0x0>;
+				compatible = "pci14e4,4433";
+				brcm,board-type = "apple,sumatra";
+				apple,antenna-sku = "XX";
+				/* To be filled by the loader */
+				local-mac-address = [00 10 18 00 00 10];
+			};
+
+			bluetooth0: network@0,1 {
+				compatible = "pci14e4,5f71";
+				brcm,board-type = "apple,sumatra";
+				// reg = <0x80100 0x0 0x0 0x0 0x0>;
+				/* To be filled by the loader */
+				local-bd-address = [00 00 00 00 00 00];
+			};
+		};
+
+		/* pci-slot6-dsp, PCIe slot-6 */
+		pci@6,0 {
+			compatible = "pci11f8,4000", "pciclass,060400", "pciclass,0604";
+			device_type = "pci";
+			reg = <0x23000 0x00 0x00 0x00 0x00>;
+			bus-range = <0x09 0x09>;
+
+			#address-cells = <3>;
+			#size-cells = <2>;
+			ranges;
+		};
+	};
 };
 
 &pcie_ge {
@@ -479,12 +996,18 @@
 	status = "ok";
 };
 
-&gpu {
-	apple,idleoff-standby-timer = <3000>;
-	apple,perf-base-pstate = <5>;
-	apple,perf-boost-ce-step = <100>;
-	apple,perf-boost-min-util = <75>;
-	apple,perf-tgt-utilization = <70>;
+/*
+ * Delete unused PCIe nodes, the Mac Pro uses slightly different PCIe
+ * controllers with a single port connected to a PM40100 PCIe switch
+ */
+/delete-node/ &pcie0;
+/delete-node/ &pcie0_dart_0;
+/delete-node/ &pcie0_dart_1;
+/delete-node/ &pcie0_dart_2;
+/delete-node/ &pcie0_dart_3;
+
+&nco_clkref {
+	clock-frequency = <1068000000>;
 };
 
 #include "spi1-nvram.dtsi"

--- a/arch/arm/dts/t6022-j475d.dts
+++ b/arch/arm/dts/t6022-j475d.dts
@@ -18,11 +18,17 @@
 / {
 	compatible = "apple,j475d", "apple,t6022", "apple,arm-platform";
 	model = "Apple Mac Studio (M2 Ultra, 2023)";
+
 	aliases {
 		atcphy4 = &atcphy0_die1;
 		atcphy5 = &atcphy1_die1;
 		/delete-property/ dcp;
+		/delete-property/ sio;
 	};
+};
+
+&sio {
+        status = "disabled";
 };
 
 &framebuffer0 {
@@ -34,6 +40,16 @@
 	dp2hdmi-pwren-gpios = <&smc_gpio 25 GPIO_ACTIVE_HIGH>;
 };
 
+/* enable PCIe port01 with SDHCI */
+&port01 {
+	pwren-gpios = <&smc_gpio 22 GPIO_ACTIVE_HIGH>;
+	status = "okay";
+};
+
+&pcie0_dart_1 {
+	status = "okay";
+};
+
 &typec4 {
 	label = "USB-C Front Right";
 };
@@ -43,7 +59,6 @@
 };
 
 /* delete unused USB nodes on die 1 */
-
 /delete-node/ &dwc3_2_dart_0_die1;
 /delete-node/ &dwc3_2_dart_1_die1;
 /delete-node/ &dwc3_2_die1;
@@ -56,9 +71,7 @@
 /delete-node/ &atcphy3_die1;
 /delete-node/ &atcphy3_xbar_die1;
 
-
 /* delete unused always-on power-domains on die 1 */
-
 /delete-node/ &ps_atc2_usb_aon_die1;
 /delete-node/ &ps_atc2_usb_die1;
 
@@ -79,3 +92,5 @@
 	compatible = "apple,j475-macaudio", "apple,j375-macaudio", "apple,macaudio";
 	model = "Mac Studio J475";
 };
+
+#include "hwmon-fan-dual.dtsi"

--- a/arch/arm/dts/t6022-jxxxd.dtsi
+++ b/arch/arm/dts/t6022-jxxxd.dtsi
@@ -13,6 +13,7 @@
 	aliases {
 		dcpext4 = &dcpext0_die1;
 		disp0 = &display;
+		sio1 = &sio_die1;
 	};
 };
 
@@ -53,20 +54,23 @@
 	apple,dptx-die = <1>;
 };
 
-/* delete missing dcp0/disp0 */
+&dpaudio1_die1 {
+	status = "okay";
+};
 
+/* delete missing dcp0/disp0 */
 /delete-node/ &disp0_dart;
 /delete-node/ &dcp_dart;
 /delete-node/ &dcp_mbox;
 /delete-node/ &dcp;
+/delete-node/ &dpaudio0;
 
-/* delete unused always-on power-domains */
+/* delete power-domains for missing disp0 / disp0_die1 */
 /delete-node/ &ps_disp0_cpu0;
 /delete-node/ &ps_disp0_fe;
 
 /delete-node/ &ps_disp0_cpu0_die1;
 /delete-node/ &ps_disp0_fe_die1;
-
 
 /* USB Type C */
 &i2c0 {
@@ -88,14 +92,14 @@
 				#size-cells = <0>;
 				port@0 {
 					reg = <0>;
-					typec4_con_hs: endpoint {
-						remote-endpoint = <&typec4_usb_hs>;
+					typec4_connector_hs: endpoint {
+						remote-endpoint = <&dwc3_4_hs>;
 					};
 				};
 				port@1 {
 					reg = <1>;
-					typec4_con_ss: endpoint {
-						remote-endpoint = <&typec4_usb_ss>;
+					typec4_connector_ss: endpoint {
+						remote-endpoint = <&atcphy4_typec_lanes>;
 					};
 				};
 			};
@@ -120,14 +124,14 @@
 				#size-cells = <0>;
 				port@0 {
 					reg = <0>;
-					typec5_con_hs: endpoint {
-						remote-endpoint = <&typec5_usb_hs>;
+					typec5_connector_hs: endpoint {
+						remote-endpoint = <&dwc3_5_hs>;
 					};
 				};
 				port@1 {
 					reg = <1>;
-					typec5_con_ss: endpoint {
-						remote-endpoint = <&typec5_usb_ss>;
+					typec5_connector_ss: endpoint {
+						remote-endpoint = <&atcphy5_typec_lanes>;
 					};
 				};
 			};
@@ -135,36 +139,89 @@
 	};
 };
 
+
 /* USB controllers on die 1 */
 &dwc3_0_die1 {
-	port {
-		typec4_usb_hs: endpoint {
-			remote-endpoint = <&typec4_con_hs>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			dwc3_4_hs: endpoint {
+				remote-endpoint = <&typec4_connector_hs>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			dwc3_4_ss: endpoint {
+				remote-endpoint = <&atcphy4_usb3>;
+			};
 		};
 	};
 };
 
 &dwc3_1_die1 {
-	port {
-		typec5_usb_hs: endpoint {
-			remote-endpoint = <&typec5_con_hs>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			dwc3_5_hs: endpoint {
+				remote-endpoint = <&typec5_connector_hs>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			dwc3_5_ss: endpoint {
+				remote-endpoint = <&atcphy5_usb3>;
+			};
 		};
 	};
 };
 
 /* Type-C PHYs */
 &atcphy0_die1 {
-	port {
-		typec4_usb_ss: endpoint {
-			remote-endpoint = <&typec4_con_ss>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			atcphy4_typec_lanes: endpoint {
+				remote-endpoint = <&typec4_connector_ss>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			atcphy4_usb3: endpoint {
+				remote-endpoint = <&dwc3_4_ss>;
+			};
 		};
 	};
 };
 
 &atcphy1_die1 {
-	port {
-		typec5_usb_ss: endpoint {
-			remote-endpoint = <&typec5_con_ss>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			atcphy5_typec_lanes: endpoint {
+				remote-endpoint = <&typec5_connector_ss>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			atcphy5_usb3: endpoint {
+				remote-endpoint = <&dwc3_5_ss>;
+			};
 		};
 	};
 };

--- a/arch/arm/dts/t6022-pcie-ge.dtsi
+++ b/arch/arm/dts/t6022-pcie-ge.dtsi
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0+ OR MIT
+/*
+ * Include PCIe-GE nodes presen on both dies of T6022 (M2 Ultra) in the
+ * Mac Pro (2023).
+ *
+ * Copyright The Asahi Linux Contributors
+ */
+
+#define DIE
+#define DIE_NO 0
+
+&die0 {
+	#include "t602x-pcie-ge.dtsi"
+};
+
+#undef DIE
+#undef DIE_NO
+
+#define DIE _die1
+#define DIE_NO 1
+
+&die1 {
+	#include "t602x-pcie-ge.dtsi"
+};
+
+#undef DIE
+#undef DIE_NO

--- a/arch/arm/dts/t6022.dtsi
+++ b/arch/arm/dts/t6022.dtsi
@@ -273,9 +273,9 @@
 		compatible = "simple-bus";
 		#address-cells = <2>;
 		#size-cells = <2>;
-		ranges = <0x2 0x0 0x2 0x0 0x4 0x0>,
-			 <0x5 0x80000000 0x5 0x80000000 0x1 0x80000000>,
-			 <0x7 0x0 0x7 0x0 0xf 0x80000000>,
+		ranges = <0x02 0x00000000 0x02 0x00000000 0x4 0x00000000>,
+			 <0x05 0x80000000 0x05 0x80000000 0x1 0x80000000>,
+			 <0x07 0x00000000 0x07 0x00000000 0xf 0x80000000>,
 			 <0x16 0x80000000 0x16 0x80000000 0x5 0x80000000>;
 		nonposted-mmio;
 		/* Required to get >32-bit DMA via DARTs */
@@ -288,8 +288,8 @@
 		compatible = "simple-bus";
 		#address-cells = <2>;
 		#size-cells = <2>;
-		ranges = <0x2 0x0 0x22 0x0 0x4 0x0>,
-			 <0x7 0x0 0x27 0x0 0xf 0x80000000>,
+		ranges = <0x02 0x00000000 0x22 0x00000000 0x4 0x00000000>,
+			 <0x07 0x00000000 0x27 0x00000000 0xf 0x80000000>,
 			 <0x16 0x80000000 0x36 0x80000000 0x5 0x80000000>;
 		nonposted-mmio;
 		/* Required to get >32-bit DMA via DARTs */
@@ -322,6 +322,8 @@
 };
 
 #include "t602x-pmgr.dtsi"
+
+/delete-node/ &ps_pmp_die1;
 
 #undef DIE
 #undef DIE_NO
@@ -358,13 +360,18 @@
 };
 
 &gpu {
-	compatible = "apple,agx-t6022", "apple,agx-g14x";
+	compatible = "apple,agx-t6022", "apple,agx-g14x", "apple,agx-g14d", "apple,agx-g14s";
 
 	apple,avg-power-filter-tc-ms = <302>;
 	apple,avg-power-ki-only = <1.0125>;
 	apple,avg-power-kp = <0.15>;
 	apple,fast-die0-integral-gain = <9.6>;
 	apple,fast-die0-proportional-gain = <24.0>;
+	apple,idleoff-standby-timer = <3000>;
+	apple,perf-base-pstate = <5>;
+	apple,perf-boost-ce-step = <100>;
+	apple,perf-boost-min-util = <75>;
+	apple,perf-tgt-utilization = <70>;
 	apple,ppm-ki = <11.0>;
 	apple,ppm-kp = <0.15>;
 };

--- a/arch/arm/dts/t602x-common.dtsi
+++ b/arch/arm/dts/t602x-common.dtsi
@@ -2,10 +2,12 @@
 /*
  * Nodes common to all T602x family SoCs (M2 Pro/Max/Ultra)
  *
+ * Other names: H14J, "Rhodes Chop", "Rhodes", "Rhodes 2C"
+ *
  * Copyright The Asahi Linux Contributors
  */
 
- / {
+/ {
 	#address-cells = <2>;
 	#size-cells = <2>;
 
@@ -32,6 +34,7 @@
 					cpu = <&cpu_e03>;
 				};
 			};
+
 			cluster1 {
 				core0 {
 					cpu = <&cpu_p00>;
@@ -70,7 +73,7 @@
 			enable-method = "spin-table";
 			cpu-release-addr = <0 0>; /* to be filled by loader */
 			next-level-cache = <&l2_cache_0>;
-			i-cache-size  = <0x20000>;
+			i-cache-size = <0x20000>;
 			d-cache-size = <0x10000>;
 			operating-points-v2 = <&blizzard_opp>;
 			capacity-dmips-mhz = <756>;
@@ -84,7 +87,7 @@
 			enable-method = "spin-table";
 			cpu-release-addr = <0 0>; /* to be filled by loader */
 			next-level-cache = <&l2_cache_0>;
-			i-cache-size  = <0x20000>;
+			i-cache-size = <0x20000>;
 			d-cache-size = <0x10000>;
 			operating-points-v2 = <&blizzard_opp>;
 			capacity-dmips-mhz = <756>;
@@ -98,7 +101,7 @@
 			enable-method = "spin-table";
 			cpu-release-addr = <0 0>; /* to be filled by loader */
 			next-level-cache = <&l2_cache_0>;
-			i-cache-size  = <0x20000>;
+			i-cache-size = <0x20000>;
 			d-cache-size = <0x10000>;
 			operating-points-v2 = <&blizzard_opp>;
 			capacity-dmips-mhz = <756>;
@@ -112,7 +115,7 @@
 			enable-method = "spin-table";
 			cpu-release-addr = <0 0>; /* to be filled by loader */
 			next-level-cache = <&l2_cache_0>;
-			i-cache-size  = <0x20000>;
+			i-cache-size = <0x20000>;
 			d-cache-size = <0x10000>;
 			operating-points-v2 = <&blizzard_opp>;
 			capacity-dmips-mhz = <756>;
@@ -598,19 +601,28 @@
 		#size-cells = <2>;
 		ranges;
 
+		gpu_globals: globals {
+			status = "disabled";
+		};
+
+		gpu_hw_cal_a: hw-cal-a {
+			status = "disabled";
+		};
+
+		gpu_hw_cal_b: hw-cal-b {
+			status = "disabled";
+		};
+
 		uat_handoff: uat-handoff {
 			reg = <0 0 0 0>;
-			no-map;
 		};
 
 		uat_pagetables: uat-pagetables {
 			reg = <0 0 0 0>;
-			no-map;
 		};
 
 		uat_ttbs: uat-ttbs {
 			reg = <0 0 0 0>;
-			no-map;
 		};
 	};
 };

--- a/arch/arm/dts/t602x-die0.dtsi
+++ b/arch/arm/dts/t602x-die0.dtsi
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0+ OR MIT
 /*
- * In anticipation of an M2 Ultra. Inspired by T600x.
- *
- * Obviously needs filling out, just the bare bones required
- * to boot to a console in the HV.
+ * Devices used on die 0 on the Apple T6022 "M2 Ultra" SoC and present on
+ * Apple T6020 / T6021 "M2 Pro" / "M2 Max".
  *
  * Copyright The Asahi Linux Contributors
  */
 
 	nco: clock-controller@28e03c000 {
-		compatible = "apple,t6020-nco", "apple,nco";
+		compatible = "apple,t6020-nco", "apple,t8103-nco", "apple,nco";
 		reg = <0x2 0x8e03c000 0x0 0x14000>;
 		clocks = <&nco_clkref>;
 		#clock-cells = <1>;
@@ -20,7 +18,7 @@
 		#interrupt-cells = <4>;
 		interrupt-controller;
 		reg = <0x2 0x8e100000 0x0 0xc000>,
-                <0x2 0x8e10c000 0x0 0x1000>;
+			<0x2 0x8e10c000 0x0 0x1000>;
 		reg-names = "core", "event";
 		power-domains = <&ps_aic>;
 	};
@@ -40,89 +38,100 @@
 		#apple,bw-scratch-cells = <3>;
 	};
 
+	nub_spmi0: spmi@29e114000 {
+		compatible = "apple,t6020-spmi", "apple,t8103-spmi", "apple,spmi";
+		reg = <0x2 0x9e114000 0x0 0x100>;
+		#address-cells = <2>;
+		#size-cells = <0>;
+
+		pmic1: pmic@f {
+			compatible = "apple,maverick-pmic", "apple,spmi-nvmem";
+			reg = <0xb SPMI_USID>;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				pm_setting: pm-setting@1405 {
+					reg = <0x1405 0x1>;
+				};
+
+				rtc_offset: rtc-offset@1411 {
+					reg = <0x1411 0x6>;
+				};
+
+				boot_stage: boot-stage@6001 {
+					reg = <0x6001 0x1>;
+				};
+
+				boot_error_count: boot-error-count@6002,0 {
+					reg = <0x6002 0x1>;
+					bits = <0 4>;
+				};
+
+				panic_count: panic-count@6002,4 {
+					reg = <0x6002 0x1>;
+					bits = <4 4>;
+				};
+
+				boot_error_stage: boot-error-stage@6003 {
+					reg = <0x6003 0x1>;
+				};
+
+				shutdown_flag: shutdown-flag@600f,3 {
+					reg = <0x600f 0x1>;
+					bits = <3 1>;
+				};
+
+				fault_shadow: fault-shadow@867b {
+					reg = <0x867b 0x10>;
+				};
+
+				socd: socd@8b00 {
+					reg = <0x8b00 0x400>;
+				};
+			};
+		};
+	};
+
 	wdt: watchdog@29e2c4000 {
-		compatible = "apple,t6020-wdt", "apple,wdt";
+		compatible = "apple,t6020-wdt", "apple,t8103-wdt", "apple,wdt";
 		reg = <0x2 0x9e2c4000 0x0 0x4000>;
 		clocks = <&clkref>;
 		interrupt-parent = <&aic>;
 		interrupts = <AIC_IRQ 0 719 IRQ_TYPE_LEVEL_HIGH>;
 	};
 
-	nub_spmi0: spmi@29e114000 {
-		compatible = "apple,t6020-spmi", "apple,spmi";
-		reg = <0x2 0x9e114000 0x0 0x100>;
-		#address-cells = <2>;
-		#size-cells = <0>;
-		interrupt-parent = <&aic>;
-		interrupts = <AIC_IRQ 0 256 IRQ_TYPE_LEVEL_HIGH>,
-			<AIC_IRQ 0 724 IRQ_TYPE_LEVEL_HIGH>;
+	smc: smc@2a2400000 {
+		compatible = "apple,t6020-smc", "apple,smc";
+		reg = <0x2 0xa2400000 0x0 0x4000>,
+			<0x2 0xa3e00000 0x0 0x100000>;
+		reg-names = "smc", "sram";
+		mboxes = <&smc_mbox>;
 
-		pmu1: pmu@f {
-			compatible = "apple,maverick-pmu", "apple,spmi-pmu";
-			reg = <0xb SPMI_USID>;
-			#address-cells = <1>;
-			#size-cells = <1>;
+		smc_gpio: gpio {
+			compatible = "apple,smc-gpio";
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
 
-			rtc_nvmem@1400 {
-				compatible = "apple,spmi-pmu-nvmem";
-				reg = <0x1400 0x20>;
-				#address-cells = <1>;
-				#size-cells = <1>;
+		smc_hwmon: hwmon {
+			compatible = "apple,smc-hwmon";
+		};
 
-				pm_setting: pm-setting@5 {
-					reg = <0x5 0x1>;
-				};
+		smc_rtc: rtc {
+			compatible = "apple,smc-rtc";
+			nvmem-cells = <&rtc_offset>;
+			nvmem-cell-names = "rtc_offset";
+		};
 
-				rtc_offset: rtc-offset@11 {
-					reg = <0x11 0x6>;
-				};
-			};
-
-			legacy_nvmem@6000 {
-				compatible = "apple,spmi-pmu-nvmem";
-				reg = <0x6000 0x20>;
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				boot_stage: boot-stage@1 {
-					reg = <0x1 0x1>;
-				};
-
-				boot_error_count: boot-error-count@2 {
-					reg = <0x2 0x1>;
-					bits = <0 4>;
-				};
-
-				panic_count: panic-count@2 {
-					reg = <0x2 0x1>;
-					bits = <4 4>;
-				};
-
-				boot_error_stage: boot-error-stage@3 {
-					reg = <0x3 0x1>;
-				};
-
-				shutdown_flag: shutdown-flag@f {
-					reg = <0xf 0x1>;
-					bits = <3 1>;
-				};
-			};
-
-			scrpad_nvmem@8000 {
-				compatible = "apple,spmi-pmu-nvmem";
-				reg = <0x8000 0x1000>;
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				fault_shadow: fault-shadow@67b {
-					reg = <0x67b 0x10>;
-				};
-
-				socd: socd@b00 {
-					reg = <0xb00 0x400>;
-				};
-			};
-
+		smc_reboot: reboot {
+			compatible = "apple,smc-reboot";
+			nvmem-cells = <&shutdown_flag>, <&boot_stage>,
+				<&boot_error_count>, <&panic_count>, <&pm_setting>;
+			nvmem-cell-names = "shutdown_flag", "boot_stage",
+				"boot_error_count", "panic_count", "pm_setting";
 		};
 	};
 
@@ -139,33 +148,8 @@
 		#mbox-cells = <0>;
 	};
 
-	smc: smc@2a2400000 {
-		compatible = "apple,t6020-smc", "apple,smc";
-		reg = <0x2 0xa2400000 0x0 0x4000>,
-			<0x2 0xa3e00000 0x0 0x100000>;
-		reg-names = "smc", "sram";
-		mboxes = <&smc_mbox>;
-
-		smc_gpio: gpio {
-			gpio-controller;
-			#gpio-cells = <2>;
-		};
-
-		smc_rtc: rtc {
-			nvmem-cells = <&rtc_offset>;
-			nvmem-cell-names = "rtc_offset";
-		};
-
-		smc_reboot: reboot {
-			nvmem-cells = <&shutdown_flag>, <&boot_stage>,
-				<&boot_error_count>, <&panic_count>, <&pm_setting>;
-			nvmem-cell-names = "shutdown_flag", "boot_stage",
-				"boot_error_count", "panic_count", "pm_setting";
-		};
-	};
-
 	pinctrl_smc: pinctrl@2a2820000 {
-		compatible = "apple,t6020-pinctrl", "apple,pinctrl";
+		compatible = "apple,t6020-pinctrl", "apple,t8103-pinctrl", "apple,pinctrl";
 		reg = <0x2 0xa2820000 0x0 0x4000>;
 
 		gpio-controller;
@@ -185,6 +169,69 @@
 				<AIC_IRQ 0 857 IRQ_TYPE_LEVEL_HIGH>;
 	};
 
+	aop_mbox: mbox@2a6408000 {
+		compatible = "apple,t6020-asc-mailbox", "apple,asc-mailbox-v4";
+		reg = <0x2 0xa6408000 0x0 0x4000>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ 0 613 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ 0 614 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ 0 615 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ 0 616 IRQ_TYPE_LEVEL_HIGH>;
+		interrupt-names = "send-empty", "send-not-empty",
+			"recv-empty", "recv-not-empty";
+		#mbox-cells = <0>;
+		status = "disabled";
+	};
+
+	aop_dart: iommu@2a6808000 {
+		compatible = "apple,t6020-dart", "apple,t8110-dart";
+		reg = <0x2 0xa6808000 0x0 0x4000>;
+		#iommu-cells = <1>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ 0 628 IRQ_TYPE_LEVEL_HIGH>;
+		status = "disabled";
+		// apple,dma-range = <0x100 0x0 0x300 0x0>;
+	};
+
+	aop_admac: dma-controller@2a6980000 {
+		compatible = "apple,t6020-admac", "apple,admac";
+		reg = <0x2 0xa6980000 0x0 0x34000>;
+		#dma-cells = <1>;
+		dma-channels = <16>;
+		interrupts-extended = <0>,
+				      <0>,
+				      <&aic AIC_IRQ 0 631 IRQ_TYPE_LEVEL_HIGH>,
+				      <0>;
+		iommus = <&aop_dart 10>;
+		status = "disabled";
+	};
+
+	aop: aop@2a6c00000 {
+		compatible = "apple,t6020-aop";
+		reg = <0x2 0xa6c00000 0x0 0x250000>,
+		      <0x2 0xa6400000 0x0 0x6c000>;
+		mboxes = <&aop_mbox>;
+		mbox-names = "mbox";
+		iommus = <&aop_dart 0>;
+
+		status = "disabled";
+
+		aop_audio: audio {
+			compatible = "apple,t6020-aop-audio", "apple,aop-audio";
+			dmas = <&aop_admac 1>;
+			dma-names = "dma";
+		};
+
+		aop_als: als {
+			compatible = "apple,t6020-aop-als", "apple,aop-als";
+			// intentionally empty
+		};
+
+		las {
+			compatible = "apple,t6020-aop-las", "apple,aop-las";
+		};
+	};
+
 	mtp: mtp@2a9400000 {
 		compatible = "apple,t6020-mtp", "apple,t6020-rtk-helper-asc4", "apple,mtp", "apple,rtk-helper-asc4";
 		reg = <0x2 0xa9400000 0x0 0x4000>,
@@ -198,7 +245,7 @@
 	};
 
 	mtp_mbox: mbox@2a9408000 {
-		compatible = "apple,t8112-asc-mailbox", "apple,asc-mailbox-v4";
+		compatible = "apple,t6020-asc-mailbox", "apple,asc-mailbox-v4";
 		reg = <0x2 0xa9408000 0x0 0x4000>;
 		interrupt-parent = <&aic>;
 		interrupts = <AIC_IRQ 0 693 IRQ_TYPE_LEVEL_HIGH>,
@@ -367,10 +414,24 @@
 		resets = <&ps_disp0_cpu0>;
 		clocks = <&clk_disp0>;
 		phandle = <&dcp>;
+		// required bus properties for 'piodma' subdevice
+		#address-cells = <2>;
+		#size-cells = <2>;
 
 		disp0_piodma: piodma {
 			iommus = <&disp0_dart 4>;
 			phandle = <&disp0_piodma>;
+		};
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port@0 {
+				reg = <0>;
+				dcp_audio: endpoint {
+					remote-endpoint = <&dpaudio0_dcp>;
+				};
+			};
 		};
 	};
 
@@ -381,13 +442,36 @@
 		phandle = <&display>;
 	};
 
-	sio_dart: iommu@39b008000 {
+	sep_dart: iommu@394ac0000 {
 		compatible = "apple,t6020-dart", "apple,t8110-dart";
-		reg = <0x3 0x9b008000 0x0 0x8000>;
-		interrupt-parent = <&aic>;
-		interrupts = <AIC_IRQ 0 1231 IRQ_TYPE_LEVEL_HIGH>;
+		reg = <0x3 0x94ac0000 0x0 0x4000>;
 		#iommu-cells = <1>;
-		power-domains = <&ps_sio_cpu>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ 0 582 IRQ_TYPE_LEVEL_HIGH>;
+		status = "disabled";
+	};
+
+	sep: sep@396400000 {
+		compatible = "apple,sep";
+		reg = <0x3 0x96400000 0x0 0x6C000>;
+		mboxes = <&sep_mbox>;
+		mbox-names = "mbox";
+		iommus = <&sep_dart 0>;
+		power-domains = <&ps_sep>;
+		status = "disabled";
+	};
+
+	sep_mbox: mbox@396408000 {
+		compatible = "apple,t6020-asc-mailbox", "apple,asc-mailbox-v4";
+		reg = <0x3 0x96408000 0x0 0x4000>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ 0 576 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ 0 577 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ 0 578 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ 0 579 IRQ_TYPE_LEVEL_HIGH>;
+		interrupt-names = "send-empty", "send-not-empty",
+			"recv-empty", "recv-not-empty";
+		#mbox-cells = <0>;
 	};
 
 	fpwm0: pwm@39b030000 {
@@ -400,7 +484,7 @@
 	};
 
 	i2c0: i2c@39b040000 {
-		compatible = "apple,t6020-i2c", "apple,i2c";
+		compatible = "apple,t6020-i2c", "apple,t8103-i2c", "apple,i2c";
 		reg = <0x3 0x9b040000 0x0 0x4000>;
 		clocks = <&clkref>;
 		interrupt-parent = <&aic>;
@@ -413,7 +497,7 @@
 	};
 
 	i2c1: i2c@39b044000 {
-		compatible = "apple,t6020-i2c", "apple,i2c";
+		compatible = "apple,t6020-i2c", "apple,t8103-i2c", "apple,i2c";
 		reg = <0x3 0x9b044000 0x0 0x4000>;
 		clocks = <&clkref>;
 		interrupt-parent = <&aic>;
@@ -427,7 +511,7 @@
 	};
 
 	i2c2: i2c@39b048000 {
-		compatible = "apple,t6020-i2c", "apple,i2c";
+		compatible = "apple,t6020-i2c", "apple,t8103-i2c", "apple,i2c";
 		reg = <0x3 0x9b048000 0x0 0x4000>;
 		clocks = <&clkref>;
 		interrupt-parent = <&aic>;
@@ -441,7 +525,7 @@
 	};
 
 	i2c3: i2c@39b04c000 {
-		compatible = "apple,t6020-i2c", "apple,i2c";
+		compatible = "apple,t6020-i2c", "apple,t8103-i2c", "apple,i2c";
 		reg = <0x3 0x9b04c000 0x0 0x4000>;
 		clocks = <&clkref>;
 		interrupt-parent = <&aic>;
@@ -455,7 +539,7 @@
 	};
 
 	i2c4: i2c@39b050000 {
-		compatible = "apple,t6020-i2c", "apple,i2c";
+		compatible = "apple,t6020-i2c", "apple,t8103-i2c", "apple,i2c";
 		reg = <0x3 0x9b050000 0x0 0x4000>;
 		clocks = <&clkref>;
 		interrupt-parent = <&aic>;
@@ -469,7 +553,7 @@
 	};
 
 	i2c5: i2c@39b054000 {
-		compatible = "apple,t6020-i2c", "apple,i2c";
+		compatible = "apple,t6020-i2c", "apple,t8103-i2c", "apple,i2c";
 		reg = <0x3 0x9b054000 0x0 0x4000>;
 		clocks = <&clkref>;
 		interrupt-parent = <&aic>;
@@ -483,7 +567,7 @@
 	};
 
 	i2c6: i2c@39b054000 {
-		compatible = "apple,t6020-i2c", "apple,i2c";
+		compatible = "apple,t6020-i2c", "apple,t8103-i2c", "apple,i2c";
 		reg = <0x3 0x9b054000 0x0 0x4000>;
 		clocks = <&clkref>;
 		interrupt-parent = <&aic>;
@@ -497,7 +581,7 @@
 	};
 
 	i2c7: i2c@39b054000 {
-		compatible = "apple,t6020-i2c", "apple,i2c";
+		compatible = "apple,t6020-i2c", "apple,t8103-i2c", "apple,i2c";
 		reg = <0x3 0x9b054000 0x0 0x4000>;
 		clocks = <&clkref>;
 		interrupt-parent = <&aic>;
@@ -511,7 +595,7 @@
 	};
 
 	i2c8: i2c@39b054000 {
-		compatible = "apple,t6020-i2c", "apple,i2c";
+		compatible = "apple,t6020-i2c", "apple,t8103-i2c", "apple,i2c";
 		reg = <0x3 0x9b054000 0x0 0x4000>;
 		clocks = <&clkref>;
 		interrupt-parent = <&aic>;
@@ -525,7 +609,7 @@
 	};
 
 	spi1: spi@39b104000 {
-		compatible = "apple,t6020-spi", "apple,spi";
+		compatible = "apple,t6020-spi", "apple,t8103-spi", "apple,spi";
 		reg = <0x3 0x9b104000 0x0 0x4000>;
 		interrupt-parent = <&aic>;
 		interrupts = <AIC_IRQ 0 1206 IRQ_TYPE_LEVEL_HIGH>;
@@ -539,7 +623,7 @@
 	};
 
 	spi2: spi@39b108000 {
-		compatible = "apple,t6020-spi", "apple,spi";
+		compatible = "apple,t6020-spi", "apple,t8103-spi", "apple,spi";
 		reg = <0x3 0x9b108000 0x0 0x4000>;
 		interrupt-parent = <&aic>;
 		interrupts = <AIC_IRQ 0 1207 IRQ_TYPE_LEVEL_HIGH>;
@@ -553,7 +637,7 @@
 	};
 
 	spi4: spi@39b110000 {
-		compatible = "apple,t6020-spi", "apple,spi";
+		compatible = "apple,t6020-spi", "apple,t8103-spi", "apple,spi";
 		reg = <0x3 0x9b110000 0x0 0x4000>;
 		interrupt-parent = <&aic>;
 		interrupts = <AIC_IRQ 0 1209 IRQ_TYPE_LEVEL_HIGH>;
@@ -583,7 +667,7 @@
 	};
 
 	admac: dma-controller@39b400000 {
-		compatible = "apple,t6020-admac", "apple,admac";
+		compatible = "apple,t6020-admac", "apple,t8103-admac", "apple,admac";
 		reg = <0x3 0x9b400000 0x0 0x34000>;
 		#dma-cells = <1>;
 		dma-channels = <16>;
@@ -596,8 +680,29 @@
 		resets = <&ps_audio_p>;
 	};
 
+	dpaudio0: audio-controller@39b500000 {
+		compatible = "apple,t6020-dpaudio", "apple,dpaudio";
+		reg = <0x3 0x9b500000 0x0 0x4000>;
+		dmas = <&sio 0x64>;
+		dma-names = "tx";
+		power-domains = <&ps_dpa0>;
+		reset-domains = <&ps_dpa0>;
+		status = "disabled";
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port@0 {
+				reg = <0>;
+				dpaudio0_dcp: endpoint {
+					remote-endpoint = <&dcp_audio>;
+				};
+			};
+		};
+	};
+
 	mca: mca@39b600000 {
-		compatible = "apple,t6020-mca", "apple,mca";
+		compatible = "apple,t6020-mca", "apple,t8103-mca", "apple,mca";
 		reg = <0x3 0x9b600000 0x0 0x10000>,
 		      <0x3 0x9b500000 0x0 0x20000>;
 		clocks = <&nco 0>, <&nco 1>, <&nco 2>, <&nco 3>;
@@ -621,7 +726,7 @@
 	};
 
 	gpu: gpu@406400000 {
-		compatible = "apple,agx-g14x";
+		compatible = "apple,agx-g14s";
 		reg = <0x4 0x6400000 0 0x40000>,
 			<0x4 0x4000000 0 0x1000000>;
 		reg-names = "asc", "sgx";
@@ -635,9 +740,12 @@
 			<AIC_IRQ 0 1142 IRQ_TYPE_LEVEL_HIGH>;
 		mboxes = <&agx_mbox>;
 		power-domains = <&ps_gfx>;
-		memory-region = <&uat_ttbs>, <&uat_pagetables>, <&uat_handoff>;
-		memory-region-names = "ttbs", "pagetables", "handoff";
+		memory-region = <&uat_ttbs>, <&uat_pagetables>, <&uat_handoff>,
+				<&gpu_hw_cal_a>, <&gpu_hw_cal_b>, <&gpu_globals>;
+		memory-region-names = "ttbs", "pagetables", "handoff",
+				      "hw-cal-a", "hw-cal-b", "globals";
 
+		apple,firmware-abi = <0 0 0>;
 		apple,firmware-version = <0 0 0>;
 		apple,firmware-compat = <0 0 0>;
 
@@ -715,15 +823,10 @@
 			<0x5 0x9e00c000 0x0 0x4000>,	/* phy0 */
 			<0x5 0x9e010000 0x0 0x4000>,	/* phy1 */
 			<0x5 0x9e014000 0x0 0x4000>,	/* phy2 */
-			<0x5 0x9e018000 0x0 0x4000>,	/* phy3 */
-			<0x5 0x9401c000 0x0 0x1000>,	/* ltssm0 */
-			<0x5 0x9501c000 0x0 0x1000>,	/* ltssm1 */
-			<0x5 0x9601c000 0x0 0x1000>,	/* ltssm2 */
-			<0x5 0x9701c000 0x0 0x1000>;	/* ltssm3 */
+			<0x5 0x9e018000 0x0 0x4000>;	/* phy3 */
 		reg-names = "config", "rc",
 			"port0", "port1", "port2", "port3",
-			"phy0", "phy1", "phy2", "phy3",
-			"ltssm0", "ltssm1", "ltssm2", "ltssm3";
+			"phy0", "phy1", "phy2", "phy3";
 
 		interrupt-parent = <&aic>;
 		interrupts = <AIC_IRQ 0 1340 IRQ_TYPE_LEVEL_HIGH>,
@@ -734,7 +837,6 @@
 		msi-controller;
 		msi-parent = <&pcie0>;
 		msi-ranges = <&aic AIC_IRQ 0 1672 IRQ_TYPE_EDGE_RISING 32>;
-
 
 		iommu-map = <0x100 &pcie0_dart_0 1 1>,
 				<0x200 &pcie0_dart_1 1 1>,

--- a/arch/arm/dts/t602x-dieX.dtsi
+++ b/arch/arm/dts/t602x-dieX.dtsi
@@ -1,25 +1,24 @@
 // SPDX-License-Identifier: GPL-2.0+ OR MIT
 /*
- * Nodes present on both dies of a hypothetical T6022 (M2 Ultra)
- * and present on M2 Pro/Max.
+ * Nodes present on both dies of T6022 (M2 Ultra) and present on M2 Pro/Max.
  *
  * Copyright The Asahi Linux Contributors
  */
 
 	DIE_NODE(cpufreq_e): cpufreq@210e20000 {
-		compatible = "apple,t6020-cluster-cpufreq", "apple,t8112-cluster-cpufreq", "apple,cluster-cpufreq";
+		compatible = "apple,t6020-cluster-cpufreq", "apple,t8112-cluster-cpufreq";
 		reg = <0x2 0x10e20000 0 0x1000>;
 		#performance-domain-cells = <0>;
 	};
 
 	DIE_NODE(cpufreq_p0): cpufreq@211e20000 {
-		compatible = "apple,t6020-cluster-cpufreq", "apple,t8112-cluster-cpufreq", "apple,cluster-cpufreq";
+		compatible = "apple,t6020-cluster-cpufreq", "apple,t8112-cluster-cpufreq";
 		reg = <0x2 0x11e20000 0 0x1000>;
 		#performance-domain-cells = <0>;
 	};
 
 	DIE_NODE(cpufreq_p1): cpufreq@212e20000 {
-		compatible = "apple,t6020-cluster-cpufreq", "apple,t8112-cluster-cpufreq", "apple,cluster-cpufreq";
+		compatible = "apple,t6020-cluster-cpufreq", "apple,t8112-cluster-cpufreq";
 		reg = <0x2 0x12e20000 0 0x1000>;
 		#performance-domain-cells = <0>;
 	};
@@ -81,35 +80,49 @@
 		phandle = <&DIE_NODE(dcpext0)>;
 		apple,dcp-index = <1>;
 		status = "disabled";
+		// required bus properties for 'piodma' subdevice
+		#address-cells = <2>;
+		#size-cells = <2>;
 
 		piodma {
 			iommus = <&DIE_NODE(dispext0_dart) 4>;
 		};
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port@0 {
+				reg = <0>;
+				DIE_NODE(dcpext0_audio): endpoint {
+					remote-endpoint = <&DIE_NODE(dpaudio1_dcp)>;
+				};
+			};
+		};
 	};
 
 	DIE_NODE(pmgr): power-management@28e080000 {
-		compatible = "apple,t6020-pmgr", "apple,pmgr", "syscon", "simple-mfd";
+		compatible = "apple,t6020-pmgr", "apple,t8103-pmgr", "syscon", "simple-mfd";
 		#address-cells = <1>;
 		#size-cells = <1>;
 		reg = <0x2 0x8e080000 0 0x8000>;
 	};
 
 	DIE_NODE(pmgr_south): power-management@28e680000 {
-		compatible = "apple,t6020-pmgr", "apple,pmgr", "syscon", "simple-mfd";
+		compatible = "apple,t6020-pmgr", "apple,t8103-pmgr", "syscon", "simple-mfd";
 		#address-cells = <1>;
 		#size-cells = <1>;
 		reg = <0x2 0x8e680000 0 0x8000>;
 	};
 
 	DIE_NODE(pmgr_east): power-management@290280000 {
-		compatible = "apple,t6020-pmgr", "apple,pmgr", "syscon", "simple-mfd";
+		compatible = "apple,t6020-pmgr", "apple,t8103-pmgr", "syscon", "simple-mfd";
 		#address-cells = <1>;
 		#size-cells = <1>;
 		reg = <0x2 0x90280000 0 0xc000>;
 	};
 
 	DIE_NODE(pinctrl_nub): pinctrl@29e1f0000 {
-		compatible = "apple,t6000-pinctrl", "apple,pinctrl";
+		compatible = "apple,t6020-pinctrl", "apple,t8103-pinctrl", "apple,pinctrl";
 		reg = <0x2 0x9e1f0000 0x0 0x4000>;
 		power-domains = <&DIE_NODE(ps_nub_gpio)>;
 
@@ -131,7 +144,7 @@
 	};
 
 	DIE_NODE(pmgr_mini): power-management@29e280000 {
-		compatible = "apple,t6000-pmgr", "apple,pmgr", "syscon", "simple-mfd";
+		compatible = "apple,t6020-pmgr", "apple,t8103-pmgr", "syscon", "simple-mfd";
 		#address-cells = <1>;
 		#size-cells = <1>;
 		reg = <0x2 0x9e280000 0 0x4000>;
@@ -145,7 +158,7 @@
 	};
 
 	DIE_NODE(pinctrl_aop): pinctrl@2a6820000 {
-		compatible = "apple,t6020-pinctrl", "apple,pinctrl";
+		compatible = "apple,t6020-pinctrl", "apple,t8103-pinctrl", "apple,pinctrl";
 		reg = <0x2 0xa6820000 0x0 0x4000>;
 
 		gpio-controller;
@@ -170,7 +183,7 @@
 		reg = <0x3 0x15304000 0x0 0x4000>;
 		#iommu-cells = <1>;
 		interrupt-parent = <&aic>;
-		interrupts = <AIC_IRQ DIE_NO 950 IRQ_TYPE_LEVEL_HIGH>;
+		interrupts = <AIC_IRQ DIE_NO 986 IRQ_TYPE_LEVEL_HIGH>;
 		power-domains = <&DIE_NODE(ps_dispext1_cpu0)>;
 		apple,dma-range = <0x100 0x0 0x10 0x0>;
 		status = "disabled";
@@ -181,7 +194,7 @@
 		reg = <0x3 0x1530c000 0x0 0x4000>;
 		#iommu-cells = <1>;
 		interrupt-parent = <&aic>;
-		interrupts = <AIC_IRQ DIE_NO 950 IRQ_TYPE_LEVEL_HIGH>;
+		interrupts = <AIC_IRQ DIE_NO 986 IRQ_TYPE_LEVEL_HIGH>;
 		power-domains = <&DIE_NODE(ps_dispext1_cpu0)>;
 		apple,dma-range = <0x100 0x0 0x10 0x0>;
 		status = "disabled";
@@ -222,14 +235,38 @@
 		phandle = <&DIE_NODE(dcpext1)>;
 		apple,dcp-index = <2>;
 		status = "disabled";
+		// required bus properties for 'piodma' subdevice
+		#address-cells = <2>;
+		#size-cells = <2>;
 
 		piodma {
 			iommus = <&DIE_NODE(dispext1_dart) 4>;
 		};
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port@0 {
+				reg = <0>;
+				DIE_NODE(dcpext1_audio): endpoint {
+					remote-endpoint = <&DIE_NODE(dpaudio2_dcp)>;
+				};
+			};
+		};
+	};
+
+	DIE_NODE(sio_dart): iommu@39b008000 {
+		compatible = "apple,t6020-dart", "apple,t8110-dart";
+		reg = <0x3 0x9b008000 0x0 0x4000>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1231 IRQ_TYPE_LEVEL_HIGH>;
+		#iommu-cells = <1>;
+		power-domains = <&DIE_NODE(ps_sio)>;
+		//apple,dma-range = <0x100 0x0001c000 0x2ff 0xfffe4000>;
 	};
 
 	DIE_NODE(pinctrl_ap): pinctrl@39b028000 {
-		compatible = "apple,t6020-pinctrl", "apple,pinctrl";
+		compatible = "apple,t6020-pinctrl", "apple,t8103-pinctrl", "apple,pinctrl";
 		reg = <0x3 0x9b028000 0x0 0x4000>;
 
 		interrupt-parent = <&aic>;
@@ -253,23 +290,154 @@
 		#interrupt-cells = <2>;
 	};
 
+	DIE_NODE(sio_mbox): mbox@39bc08000 {
+		compatible = "apple,t6020-asc-mailbox", "apple,asc-mailbox-v4";
+		reg = <0x3 0x9bc08000 0x0 0x4000>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1248 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ DIE_NO 1249 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ DIE_NO 1250 IRQ_TYPE_LEVEL_HIGH>,
+			<AIC_IRQ DIE_NO 1251 IRQ_TYPE_LEVEL_HIGH>;
+		interrupt-names = "send-empty", "send-not-empty",
+			"recv-empty", "recv-not-empty";
+		#mbox-cells = <0>;
+		power-domains = <&DIE_NODE(ps_sio_cpu)>;
+	};
+
+	DIE_NODE(sio): sio@39bc00000 {
+		compatible = "apple,t6020-sio", "apple,sio";
+		reg = <0x3 0x9bc00000 0x0 0x8000>;
+		dma-channels = <128>;
+		#dma-cells = <1>;
+		mboxes = <&DIE_NODE(sio_mbox)>;
+		iommus = <&DIE_NODE(sio_dart) 0>;
+		power-domains = <&DIE_NODE(ps_sio_cpu)>;
+		resets = <&DIE_NODE(ps_sio_cpu)>;
+		status = "disabled";
+	};
+
+	DIE_NODE(dpaudio1): audio-controller@39b504000 {
+		compatible = "apple,t6020-dpaudio", "apple,dpaudio";
+		reg = <0x3 0x9b540000 0x0 0x4000>;
+		dmas = <&DIE_NODE(sio) 0x66>;
+		dma-names = "tx";
+		power-domains = <&DIE_NODE(ps_dpa1)>;
+		reset-domains = <&DIE_NODE(ps_dpa1)>;
+		status = "disabled";
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port@0 {
+				reg = <0>;
+				DIE_NODE(dpaudio1_dcp): endpoint {
+					remote-endpoint = <&DIE_NODE(dcpext0_audio)>;
+				};
+			};
+		};
+	};
+
+	DIE_NODE(dpaudio2): audio-controller@39b508000 {
+		compatible = "apple,t6020-dpaudio", "apple,dpaudio";
+		reg = <0x3 0x9b580000 0x0 0x4000>;
+		dmas = <&DIE_NODE(sio) 0x68>;
+		dma-names = "tx";
+		power-domains = <&DIE_NODE(ps_dpa2)>;
+		reset-domains = <&DIE_NODE(ps_dpa2)>;
+		status = "disabled";
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port@0 {
+				reg = <0>;
+				DIE_NODE(dpaudio2_dcp): endpoint {
+					remote-endpoint = <&DIE_NODE(dcpext1_audio)>;
+				};
+			};
+		};
+	};
+
+	/*
+	 * omit dpaudio3 / 4 as long as the linked dcpext nodes don't exist
+	 *
+	DIE_NODE(dpaudio3): audio-controller@39b50c000 {
+		compatible = "apple,t6020-dpaudio", "apple,dpaudio";
+		reg = <0x3 0x9b5c0000 0x0 0x4000>;
+		dmas = <&DIE_NODE(sio) 0x6a>;
+		dma-names = "tx";
+		power-domains = <&DIE_NODE(ps_dpa3)>;
+		reset-domains = <&DIE_NODE(ps_dpa3)>;
+		status = "disabled";
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port@0 {
+				reg = <0>;
+				DIE_NODE(dpaudio3_dcp): endpoint {
+					remote-endpoint = <&DIE_NODE(dcpext2_audio)>;
+				};
+			};
+		};
+	};
+
+	DIE_NODE(dpaudio4): audio-controller@39b510000 {
+		compatible = "apple,t6020-dpaudio", "apple,dpaudio";
+		reg = <0x3 0x9b500000 0x0 0x4000>;
+		dmas = <&DIE_NODE(sio) 0x6c>;
+		dma-names = "tx";
+		power-domains = <&DIE_NODE(ps_dpa4)>;
+		reset-domains = <&DIE_NODE(ps_dpa4)>;
+		status = "disabled";
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			port@0 {
+				reg = <0>;
+				DIE_NODE(dpaudio4_dcp): endpoint {
+					remote-endpoint = <&DIE_NODE(dcpext3_audio)>;
+				};
+			};
+		};
+	};
+	*/
+
 	DIE_NODE(lpdptxphy): phy@39c000000 {
 		compatible = "apple,t6020-dptx-phy", "apple,dptx-phy";
 		reg = <0x3 0x9c000000 0x0 0x4000>,
 			<0x3 0x9c040000 0x0 0xc000>;
 		reg-names = "core", "dptx";
-		power-domain = <&DIE_NODE(ps_dptx_phy_ps)>;
+		power-domains = <&DIE_NODE(ps_dptx_phy_ps)>;
 		#phy-cells = <0>;
 		#reset-cells = <0>;
 		status = "disabled"; /* only exposed on desktop devices */
 	};
 
 	DIE_NODE(pmgr_gfx): power-management@404e80000 {
-		compatible = "apple,t6020-pmgr", "apple,pmgr", "syscon", "simple-mfd";
+		compatible = "apple,t6020-pmgr", "apple,t8103-pmgr", "syscon", "simple-mfd";
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		reg = <0x4 0x4e80000 0 0x4000>;
+	};
+
+	DIE_NODE(dwc3_0): usb@702280000 {
+		compatible = "apple,t6020-dwc3", "apple,t8103-dwc3";
+		reg = <0x7 0x02280000 0x0 0xcd00>, <0x7 0x0228cd00 0x0 0x3200>;
+		reg-names = "dwc3-core", "dwc3-apple";
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1256 IRQ_TYPE_LEVEL_HIGH>;
+		dr_mode = "otg";
+		usb-role-switch;
+		role-switch-default-mode = "host";
+		iommus = <&DIE_NODE(dwc3_0_dart_0) 0>,
+			<&DIE_NODE(dwc3_0_dart_1) 1>;
+		power-domains = <&DIE_NODE(ps_atc0_usb)>;
+		resets = <&DIE_NODE(atcphy0)>;
+		phys = <&DIE_NODE(atcphy0) PHY_TYPE_USB2>, <&DIE_NODE(atcphy0) PHY_TYPE_USB3>;
+		phy-names = "usb2-phy", "usb3-phy";
 	};
 
 	DIE_NODE(dwc3_0_dart_0): iommu@702f00000 {
@@ -290,23 +458,6 @@
 		#iommu-cells = <1>;
 	};
 
-	DIE_NODE(dwc3_0): usb@702280000 {
-		compatible = "apple,t6020-dwc3", "apple,dwc3", "snps,dwc3";
-		reg = <0x7 0x02280000 0x0 0x100000>;
-		interrupt-parent = <&aic>;
-		interrupts = <AIC_IRQ DIE_NO 1256 IRQ_TYPE_LEVEL_HIGH>;
-		dr_mode = "otg";
-		usb-role-switch;
-		role-switch-default-mode = "host";
-		iommus = <&DIE_NODE(dwc3_0_dart_0) 0>,
-			<&DIE_NODE(dwc3_0_dart_1) 1>;
-		power-domains = <&DIE_NODE(ps_atc0_usb)>;
-		dma-coherent;
-		resets = <&DIE_NODE(atcphy0)>;
-		phys = <&DIE_NODE(atcphy0) PHY_TYPE_USB2>, <&DIE_NODE(atcphy0) PHY_TYPE_USB3>;
-		phy-names = "usb2-phy", "usb3-phy";
-	};
-
 	DIE_NODE(atcphy0): phy@703000000 {
 		compatible = "apple,t6020-atcphy", "apple,t8103-atcphy";
 		reg = <0x7 0x03000000 0x0 0x4c000>,
@@ -322,7 +473,6 @@
 
 		orientation-switch;
 		mode-switch;
-		svid = <0xff01>, <0x8087>;
 		power-domains = <&DIE_NODE(ps_atc0_usb)>;
 	};
 
@@ -332,6 +482,23 @@
 		#mux-control-cells = <1>;
 		power-domains = <&DIE_NODE(ps_atc0_usb)>;
 		status = "disabled";
+	};
+
+	DIE_NODE(dwc3_1): usb@b02280000 {
+		compatible = "apple,t6020-dwc3", "apple,t8103-dwc3";
+		reg = <0xb 0x02280000 0x0 0xcd00>, <0xb 0x0228cd00 0x0 0x3200>;
+		reg-names = "dwc3-core", "dwc3-apple";
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1274 IRQ_TYPE_LEVEL_HIGH>;
+		dr_mode = "otg";
+		usb-role-switch;
+		role-switch-default-mode = "host";
+		iommus = <&DIE_NODE(dwc3_1_dart_0) 0>,
+			<&DIE_NODE(dwc3_1_dart_1) 1>;
+		power-domains = <&DIE_NODE(ps_atc1_usb)>;
+		resets = <&DIE_NODE(atcphy1)>;
+		phys = <&DIE_NODE(atcphy1) PHY_TYPE_USB2>, <&DIE_NODE(atcphy1) PHY_TYPE_USB3>;
+		phy-names = "usb2-phy", "usb3-phy";
 	};
 
 	DIE_NODE(dwc3_1_dart_0): iommu@b02f00000 {
@@ -352,23 +519,6 @@
 		#iommu-cells = <1>;
 	};
 
-	DIE_NODE(dwc3_1): usb@b02280000 {
-		compatible = "apple,t6020-dwc3", "apple,dwc3", "snps,dwc3";
-		reg = <0xb 0x02280000 0x0 0x100000>;
-		interrupt-parent = <&aic>;
-		interrupts = <AIC_IRQ DIE_NO 1274 IRQ_TYPE_LEVEL_HIGH>;
-		dr_mode = "otg";
-		usb-role-switch;
-		role-switch-default-mode = "host";
-		iommus = <&DIE_NODE(dwc3_1_dart_0) 0>,
-			<&DIE_NODE(dwc3_1_dart_1) 1>;
-		power-domains = <&DIE_NODE(ps_atc1_usb)>;
-		dma-coherent;
-		resets = <&DIE_NODE(atcphy1)>;
-		phys = <&DIE_NODE(atcphy1) PHY_TYPE_USB2>, <&DIE_NODE(atcphy1) PHY_TYPE_USB3>;
-		phy-names = "usb2-phy", "usb3-phy";
-	};
-
 	DIE_NODE(atcphy1): phy@b03000000 {
 		compatible = "apple,t6020-atcphy", "apple,t8103-atcphy";
 		reg = <0xb 0x03000000 0x0 0x4c000>,
@@ -384,7 +534,6 @@
 
 		orientation-switch;
 		mode-switch;
-		svid = <0xff01>, <0x8087>;
 		power-domains = <&DIE_NODE(ps_atc1_usb)>;
 	};
 
@@ -394,6 +543,23 @@
 		#mux-control-cells = <1>;
 		power-domains = <&DIE_NODE(ps_atc1_usb)>;
 		status = "disabled";
+	};
+
+	DIE_NODE(dwc3_2): usb@f02280000 {
+		compatible = "apple,t6020-dwc3", "apple,t8103-dwc3";
+		reg = <0xf 0x02280000 0x0 0xcd00>, <0xf 0x0228cd00 0x0 0x3200>;
+		reg-names = "dwc3-core", "dwc3-apple";
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1292 IRQ_TYPE_LEVEL_HIGH>;
+		dr_mode = "otg";
+		usb-role-switch;
+		role-switch-default-mode = "host";
+		iommus = <&DIE_NODE(dwc3_2_dart_0) 0>,
+			<&DIE_NODE(dwc3_2_dart_1) 1>;
+		power-domains = <&DIE_NODE(ps_atc2_usb)>;
+		resets = <&DIE_NODE(atcphy2)>;
+		phys = <&DIE_NODE(atcphy2) PHY_TYPE_USB2>, <&DIE_NODE(atcphy2) PHY_TYPE_USB3>;
+		phy-names = "usb2-phy", "usb3-phy";
 	};
 
 	DIE_NODE(dwc3_2_dart_0): iommu@f02f00000 {
@@ -414,23 +580,6 @@
 		#iommu-cells = <1>;
 	};
 
-	DIE_NODE(dwc3_2): usb@f02280000 {
-		compatible = "apple,t6020-dwc3", "apple,dwc3", "snps,dwc3";
-		reg = <0xf 0x02280000 0x0 0x100000>;
-		interrupt-parent = <&aic>;
-		interrupts = <AIC_IRQ DIE_NO 1292 IRQ_TYPE_LEVEL_HIGH>;
-		dr_mode = "otg";
-		usb-role-switch;
-		role-switch-default-mode = "host";
-		iommus = <&DIE_NODE(dwc3_2_dart_0) 0>,
-			<&DIE_NODE(dwc3_2_dart_1) 1>;
-		power-domains = <&DIE_NODE(ps_atc2_usb)>;
-		dma-coherent;
-		resets = <&DIE_NODE(atcphy2)>;
-		phys = <&DIE_NODE(atcphy2) PHY_TYPE_USB2>, <&DIE_NODE(atcphy2) PHY_TYPE_USB3>;
-		phy-names = "usb2-phy", "usb3-phy";
-	};
-
 	DIE_NODE(atcphy2): phy@f03000000 {
 		compatible = "apple,t6020-atcphy", "apple,t8103-atcphy";
 		reg = <0xf 0x03000000 0x0 0x4c000>,
@@ -446,7 +595,6 @@
 
 		orientation-switch;
 		mode-switch;
-		svid = <0xff01>, <0x8087>;
 		power-domains = <&DIE_NODE(ps_atc2_usb)>;
 	};
 
@@ -456,6 +604,23 @@
 		#mux-control-cells = <1>;
 		power-domains = <&DIE_NODE(ps_atc2_usb)>;
 		status = "disabled";
+	};
+
+	DIE_NODE(dwc3_3): usb@1302280000 {
+		compatible = "apple,t6020-dwc3", "apple,t8103-dwc3";
+		reg = <0x13 0x02280000 0x0 0xcd00>, <0x13 0x0228cd00 0x0 0x3200>;
+		reg-names = "dwc3-core", "dwc3-apple";
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1310 IRQ_TYPE_LEVEL_HIGH>;
+		dr_mode = "otg";
+		usb-role-switch;
+		role-switch-default-mode = "host";
+		iommus = <&DIE_NODE(dwc3_3_dart_0) 0>,
+			<&DIE_NODE(dwc3_3_dart_1) 1>;
+		power-domains = <&DIE_NODE(ps_atc3_usb)>;
+		resets = <&DIE_NODE(atcphy3)>;
+		phys = <&DIE_NODE(atcphy3) PHY_TYPE_USB2>, <&DIE_NODE(atcphy3) PHY_TYPE_USB3>;
+		phy-names = "usb2-phy", "usb3-phy";
 	};
 
 	DIE_NODE(dwc3_3_dart_0): iommu@1302f00000 {
@@ -476,23 +641,6 @@
 		#iommu-cells = <1>;
 	};
 
-	DIE_NODE(dwc3_3): usb@1302280000 {
-		compatible = "apple,t6020-dwc3", "apple,dwc3", "snps,dwc3";
-		reg = <0x13 0x02280000 0x0 0x100000>;
-		interrupt-parent = <&aic>;
-		interrupts = <AIC_IRQ DIE_NO 1310 IRQ_TYPE_LEVEL_HIGH>;
-		dr_mode = "otg";
-		usb-role-switch;
-		role-switch-default-mode = "host";
-		iommus = <&DIE_NODE(dwc3_3_dart_0) 0>,
-			<&DIE_NODE(dwc3_3_dart_1) 1>;
-		power-domains = <&DIE_NODE(ps_atc3_usb)>;
-		dma-coherent;
-		resets = <&DIE_NODE(atcphy3)>;
-		phys = <&DIE_NODE(atcphy3) PHY_TYPE_USB2>, <&DIE_NODE(atcphy3) PHY_TYPE_USB3>;
-		phy-names = "usb2-phy", "usb3-phy";
-	};
-
 	DIE_NODE(atcphy3): phy@1303000000 {
 		compatible = "apple,t6020-atcphy", "apple,t8103-atcphy";
 		reg = <0x13 0x03000000 0x0 0x4c000>,
@@ -508,7 +656,6 @@
 
 		orientation-switch;
 		mode-switch;
-		svid = <0xff01>, <0x8087>;
 		power-domains = <&DIE_NODE(ps_atc3_usb)>;
 	};
 
@@ -519,67 +666,3 @@
 		power-domains = <&DIE_NODE(ps_atc3_usb)>;
 		status = "disabled";
 	};
-
-	DIE_NODE(pcie_ge): pcie@1680000000 {
-		compatible = "apple,t6020-pcie-ge", "apple,t6020-pcie";
-		device_type = "pci";
-
-		reg = <0x16 0x80000000 0x0 0x1000000>,	/* config */
-			<0x16 0x91000000 0x0 0x4000>,	/* rc */
-			<0x16 0x94008000 0x0 0x4000>,	/* port0 */
-			<0x16 0x9e01c000 0x0 0x4000>,	/* phy0 */
-			<0x16 0x9401c000 0x0 0x1000>;	/* ltssm0 */
-		reg-names = "config", "rc", "port0", "phy0", "ltssm0";
-
-		interrupt-parent = <&aic>;
-		interrupts = <AIC_IRQ DIE_NO 1356 IRQ_TYPE_LEVEL_HIGH>;
-
-		msi-controller;
-		msi-parent = <&pcie0>;
-		msi-ranges = <&aic AIC_IRQ DIE_NO 1672 IRQ_TYPE_EDGE_RISING 32>;
-
-
-		iommu-map = <0x100 &pcie_ge_dart 1 1>;
-		iommu-map-mask = <0xff00>;
-
-		bus-range = <0 1>;
-		#address-cells = <3>;
-		#size-cells = <2>;
-		ranges = <0x43000000 0x18 0x00000000 0x18 0x00000000 0x4 0x00000000>,
-				<0x02000000 0x0 0x80000000 0x17 0x80000000 0x0 0x80000000>;
-
-		power-domains = <&ps_apcie_ge_sys>;
-		pinctrl-0 = <&DIE_NODE(pcie_ge_pins)>;
-		pinctrl-names = "default";
-
-		dma-coherent;
-
-		status = "disabled";
-
-		DIE_NODE(port_ge00): pci@0,0 {
-			device_type = "pci";
-			reg = <0x0 0x0 0x0 0x0 0x0>;
-			reset-gpios = <&DIE_NODE(pinctrl_ap) 9 GPIO_ACTIVE_LOW>;
-
-			#address-cells = <3>;
-			#size-cells = <2>;
-			ranges;
-
-			interrupt-controller;
-			#interrupt-cells = <1>;
-
-			interrupt-map-mask = <0 0 0 7>;
-			interrupt-map = <0 0 0 1 &port00 0 0 0 0>;
-		};
-	};
-
-	DIE_NODE(pcie_ge_dart): iommu@1694000000 {
-		compatible = "apple,t6020-dart", "apple,t8110-dart";
-		reg = <0x16 0x94000000 0x0 0x4000>;
-		#iommu-cells = <1>;
-		interrupt-parent = <&aic>;
-		interrupts = <AIC_IRQ DIE_NO 1357 IRQ_TYPE_LEVEL_HIGH>;
-		power-domains = <&ps_apcie_ge_sys>;
-		status = "disabled";
-	};
-

--- a/arch/arm/dts/t602x-gpio-pins.dtsi
+++ b/arch/arm/dts/t602x-gpio-pins.dtsi
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0+ OR MIT
 /*
- * GPIO pin mappings for Apple T600x SoCs.
+ * GPIO pin mappings for Apple T602x SoCs.
  *
  * Copyright The Asahi Linux Contributors
  */

--- a/arch/arm/dts/t602x-j414-j416.dtsi
+++ b/arch/arm/dts/t602x-j414-j416.dtsi
@@ -23,6 +23,10 @@
 	};
 };
 
+&framebuffer0 {
+	power-domains = <&ps_disp0_cpu0>, <&ps_dptx_phy_ps>;
+};
+
 /* HACK: keep dptx_phy_ps power-domain always-on
  *       it is unclear how to sequence with dcp for the integrated display
  */

--- a/arch/arm/dts/t602x-j474-j475.dtsi
+++ b/arch/arm/dts/t602x-j474-j475.dtsi
@@ -1,24 +1,24 @@
 // SPDX-License-Identifier: GPL-2.0+ OR MIT
 /*
- * Mac Mini (M2 Pro, 2023) and Mac Studio (2023)
+ * Mac mini (M2 Pro, 2023) and Mac Studio (2023)
  *
  * This file contains the parts common to J474 and J475 devices with t6020,
  * t6021 and t6022.
  *
- * target-type: J474s / J375c / J375d
+ * target-type: J474s / J475c / J475d
  *
  * Copyright The Asahi Linux Contributors
  */
 
 /*
- * These model is very similar to the previous generation Mac Studio, other than
- * the GPIO indices.
+ * These models are very similar to the previous generation Mac Studio, other
+ * than GPIO indices.
  */
 
 #include "t600x-j375.dtsi"
 
 &framebuffer0 {
-	power-domains = <&ps_disp0_cpu0>, <&ps_dptx_phy_ps>;
+	power-domains = <&ps_dispext0_cpu0>, <&ps_dptx_phy_ps>;
 };
 
 &hpm0 {
@@ -41,17 +41,6 @@
 &port00 {
 	pwren-gpios = <&smc_gpio 13 GPIO_ACTIVE_HIGH>;
 };
-
-#ifndef NO_PCIE_SDHC
-&port01 {
-	pwren-gpios = <&smc_gpio 22 GPIO_ACTIVE_HIGH>;
-	status = "okay";
-};
-
-&pcie0_dart_1 {
-	status = "okay";
-};
-#endif
 
 &port03 {
 	/* USB xHCI */

--- a/arch/arm/dts/t602x-nvme.dtsi
+++ b/arch/arm/dts/t602x-nvme.dtsi
@@ -26,7 +26,7 @@
 	};
 
 	DIE_NODE(nvme): nvme@34bcc0000 {
-		compatible = "apple,t6020-nvme-ans2", "apple,nvme-ans2";
+		compatible = "apple,t6020-nvme-ans2", "apple,t8103-nvme-ans2", "apple,nvme-ans2";
 		reg = <0x3 0x4bcc0000 0x0 0x40000>, <0x3 0x47400000 0x0 0x4000>;
 		reg-names = "nvme", "ans";
 		interrupt-parent = <&aic>;

--- a/arch/arm/dts/t602x-pcie-ge.dtsi
+++ b/arch/arm/dts/t602x-pcie-ge.dtsi
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0+ OR MIT
+/*
+ * PCIe-GE Nodes present on both dies of a T6022 (M2 Ultra) and M2 Pro/Max but
+ * only used on T6022 in the Mac Pro (2023).
+ *
+ * Copyright The Asahi Linux Contributors
+ */
+
+	DIE_NODE(pcie_ge): pcie@1680000000 {
+		compatible = "apple,t6020-pcie-ge", "apple,t6020-pcie";
+		device_type = "pci";
+
+		reg = <0x16 0x80000000 0x0 0x1000000>,	/* config */
+			<0x16 0x91000000 0x0 0x4000>,	/* rc */
+			<0x16 0x94008000 0x0 0x4000>,	/* port0 */
+			<0x16 0x9e01c000 0x0 0x4000>,	/* phy0 */
+			<0x16 0x9401c000 0x0 0x1000>;	/* ltssm0 */
+		reg-names = "config", "rc", "port0", "phy0", "ltssm0";
+
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1356 IRQ_TYPE_LEVEL_HIGH>;
+
+		msi-controller;
+		msi-parent = <&DIE_NODE(pcie_ge)>;
+		msi-ranges = <&aic AIC_IRQ DIE_NO 1672 IRQ_TYPE_EDGE_RISING 128>;
+
+		iommu-map = <0x000 &DIE_NODE(pcie_ge_dart) 0 0>,
+			    <0x100 &DIE_NODE(pcie_ge_dart) 1 1>,
+			    <0x200 &DIE_NODE(pcie_ge_dart) 2 2>,
+			    <0x300 &DIE_NODE(pcie_ge_dart) 3 3>,
+			    <0x400 &DIE_NODE(pcie_ge_dart) 4 4>,
+			    <0x500 &DIE_NODE(pcie_ge_dart) 5 5>,
+			    <0x600 &DIE_NODE(pcie_ge_dart) 6 6>,
+			    <0x700 &DIE_NODE(pcie_ge_dart) 7 7>,
+			    <0x800 &DIE_NODE(pcie_ge_dart) 8 8>,
+			    <0x900 &DIE_NODE(pcie_ge_dart) 9 9>,
+			    <0xa00 &DIE_NODE(pcie_ge_dart) 10 10>,
+			    <0xb00 &DIE_NODE(pcie_ge_dart) 11 11>,
+			    <0xc00 &DIE_NODE(pcie_ge_dart) 12 12>,
+			    <0xd00 &DIE_NODE(pcie_ge_dart) 13 13>,
+			    <0xe00 &DIE_NODE(pcie_ge_dart) 14 14>,
+			    <0xf00 &DIE_NODE(pcie_ge_dart) 15 15>;
+		iommu-map-mask = <0xff00>;
+
+		bus-range = <0 15>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges = <0x43000000 0x18 0x00000000 0x18 0x00000000 0x4 0x00000000>,
+			 <0x02000000 0x00 0x80000000 0x17 0x80000000 0x0 0x80000000>;
+
+		power-domains = <&DIE_NODE(ps_apcie_ge_sys)>;
+		pinctrl-0 = <&DIE_NODE(pcie_ge_pins)>;
+		pinctrl-names = "default";
+
+		dma-coherent;
+
+		status = "disabled";
+
+		DIE_NODE(port_ge00): pci@0,0 {
+			device_type = "pci";
+			reg = <0x0 0x0 0x0 0x0 0x0>;
+			reset-gpios = <&DIE_NODE(pinctrl_ap) 9 GPIO_ACTIVE_LOW>;
+
+			#address-cells = <3>;
+			#size-cells = <2>;
+			ranges;
+
+			interrupt-controller;
+			#interrupt-cells = <1>;
+
+			interrupt-map-mask = <0 0 0 7>;
+			interrupt-map = <0 0 0 1 &DIE_NODE(port_ge00) 0 0 0 0>,
+					<0 0 0 2 &DIE_NODE(port_ge00) 0 0 0 1>,
+					<0 0 0 3 &DIE_NODE(port_ge00) 0 0 0 2>,
+					<0 0 0 4 &DIE_NODE(port_ge00) 0 0 0 3>;
+		};
+	};
+
+	DIE_NODE(pcie_ge_dart): iommu@1694000000 {
+		compatible = "apple,t6020-dart", "apple,t8110-dart";
+		reg = <0x16 0x94000000 0x0 0x4000>;
+		#iommu-cells = <1>;
+		interrupt-parent = <&aic>;
+		interrupts = <AIC_IRQ DIE_NO 1357 IRQ_TYPE_LEVEL_HIGH>;
+		power-domains = <&DIE_NODE(ps_apcie_ge_sys)>;
+		status = "disabled";
+	};

--- a/arch/arm/dts/t602x-pmgr.dtsi
+++ b/arch/arm/dts/t602x-pmgr.dtsi
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0+ OR MIT
 /*
- * PMGR Power domains for the Apple T6001 "M1 Max" SoC
+ * PMGR Power domains for Apple T602x "M2 Pro/Max/Ultra" SoC
  *
  * Copyright The Asahi Linux Contributors
  */
 
 &DIE_NODE(pmgr) {
 	DIE_NODE(ps_afi): power-controller@100 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x100 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -16,7 +16,7 @@
 	};
 
 	DIE_NODE(ps_aic): power-controller@108 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x108 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -25,7 +25,7 @@
 	};
 
 	DIE_NODE(ps_dwi): power-controller@110 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x110 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -33,7 +33,7 @@
 	};
 
 	DIE_NODE(ps_pms): power-controller@118 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x118 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -42,7 +42,7 @@
 	};
 
 	DIE_NODE(ps_gpio): power-controller@120 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x120 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -51,7 +51,7 @@
 	};
 
 	DIE_NODE(ps_soc_dpe): power-controller@128 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x128 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -60,7 +60,7 @@
 	};
 
 	DIE_NODE(ps_pms_c1ppt): power-controller@130 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x130 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -69,7 +69,7 @@
 	};
 
 	DIE_NODE(ps_pmgr_soc_ocla): power-controller@138 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x138 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -78,7 +78,7 @@
 	};
 
 	DIE_NODE(ps_amcc0): power-controller@168 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x168 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -87,7 +87,7 @@
 	};
 
 	DIE_NODE(ps_amcc2): power-controller@170 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x170 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -96,7 +96,7 @@
 	};
 
 	DIE_NODE(ps_dcs_00): power-controller@178 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x178 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -105,7 +105,7 @@
 	};
 
 	DIE_NODE(ps_dcs_01): power-controller@180 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x180 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -114,7 +114,7 @@
 	};
 
 	DIE_NODE(ps_dcs_02): power-controller@188 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x188 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -123,7 +123,7 @@
 	};
 
 	DIE_NODE(ps_dcs_03): power-controller@190 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x190 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -132,7 +132,7 @@
 	};
 
 	DIE_NODE(ps_dcs_08): power-controller@198 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x198 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -141,7 +141,7 @@
 	};
 
 	DIE_NODE(ps_dcs_09): power-controller@1a0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1a0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -150,7 +150,7 @@
 	};
 
 	DIE_NODE(ps_dcs_10): power-controller@1a8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1a8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -159,7 +159,7 @@
 	};
 
 	DIE_NODE(ps_dcs_11): power-controller@1b0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1b0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -168,7 +168,7 @@
 	};
 
 	DIE_NODE(ps_afnc1_ioa): power-controller@1b8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1b8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -178,7 +178,7 @@
 	};
 
 	DIE_NODE(ps_afc): power-controller@1d0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1d0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -187,7 +187,7 @@
 	};
 
 	DIE_NODE(ps_afnc0_ioa): power-controller@1e8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1e8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -197,7 +197,7 @@
 	};
 
 	DIE_NODE(ps_afnc1_ls): power-controller@1f0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1f0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -207,7 +207,7 @@
 	};
 
 	DIE_NODE(ps_afnc0_ls): power-controller@1f8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1f8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -217,7 +217,7 @@
 	};
 
 	DIE_NODE(ps_afnc1_lw0): power-controller@200 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x200 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -227,7 +227,7 @@
 	};
 
 	DIE_NODE(ps_afnc1_lw1): power-controller@208 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x208 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -237,7 +237,7 @@
 	};
 
 	DIE_NODE(ps_afnc1_lw2): power-controller@210 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x210 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -247,7 +247,7 @@
 	};
 
 	DIE_NODE(ps_afnc0_lw0): power-controller@218 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x218 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -257,7 +257,7 @@
 	};
 
 	DIE_NODE(ps_scodec): power-controller@220 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x220 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -266,7 +266,7 @@
 	};
 
 	DIE_NODE(ps_atc0_common): power-controller@228 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x228 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -275,7 +275,7 @@
 	};
 
 	DIE_NODE(ps_atc1_common): power-controller@230 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x230 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -284,7 +284,7 @@
 	};
 
 	DIE_NODE(ps_atc2_common): power-controller@238 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x238 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -293,7 +293,7 @@
 	};
 
 	DIE_NODE(ps_atc3_common): power-controller@240 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x240 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -302,7 +302,7 @@
 	};
 
 	DIE_NODE(ps_dispext1_sys): power-controller@248 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x248 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -311,7 +311,7 @@
 	};
 
 	DIE_NODE(ps_pms_bridge): power-controller@250 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x250 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -321,7 +321,7 @@
 	};
 
 	DIE_NODE(ps_dispext0_sys): power-controller@258 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x258 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -330,7 +330,7 @@
 	};
 
 	DIE_NODE(ps_ane_sys): power-controller@260 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x260 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -339,7 +339,7 @@
 	};
 
 	DIE_NODE(ps_avd_sys): power-controller@268 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x268 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -348,7 +348,7 @@
 	};
 
 	DIE_NODE(ps_atc0_cio): power-controller@270 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x270 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -357,7 +357,7 @@
 	};
 
 	DIE_NODE(ps_atc0_pcie): power-controller@278 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x278 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -366,7 +366,7 @@
 	};
 
 	DIE_NODE(ps_atc1_cio): power-controller@280 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x280 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -375,7 +375,7 @@
 	};
 
 	DIE_NODE(ps_atc1_pcie): power-controller@288 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x288 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -384,7 +384,7 @@
 	};
 
 	DIE_NODE(ps_atc2_cio): power-controller@290 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x290 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -393,7 +393,7 @@
 	};
 
 	DIE_NODE(ps_atc2_pcie): power-controller@298 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x298 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -402,7 +402,7 @@
 	};
 
 	DIE_NODE(ps_atc3_cio): power-controller@2a0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x2a0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -411,7 +411,7 @@
 	};
 
 	DIE_NODE(ps_atc3_pcie): power-controller@2a8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x2a8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -420,7 +420,7 @@
 	};
 
 	DIE_NODE(ps_dispext1_fe): power-controller@2b0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x2b0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -429,7 +429,7 @@
 	};
 
 	DIE_NODE(ps_dispext1_cpu0): power-controller@2b8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x2b8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -439,7 +439,7 @@
 	};
 
 	DIE_NODE(ps_dispext0_fe): power-controller@2c0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x2c0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -447,19 +447,17 @@
 		power-domains = <&DIE_NODE(ps_dispext0_sys)>;
 	};
 
-#if DIE_NO == 0
-	/* PMP is only present on die 0 of the M1 Ultra */
+	/* PMP is only present on die 0 of the M2 Ultra */
 	DIE_NODE(ps_pmp): power-controller@2c8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x2c8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
 		label = DIE_LABEL(pmp);
 	};
-#endif
 
 	DIE_NODE(ps_pms_sram): power-controller@2d0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x2d0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -467,7 +465,7 @@
 	};
 
 	DIE_NODE(ps_dispext0_cpu0): power-controller@2d8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x2d8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -477,7 +475,7 @@
 	};
 
 	DIE_NODE(ps_ane_cpu): power-controller@2e0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x2e0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -486,7 +484,7 @@
 	};
 
 	DIE_NODE(ps_atc0_cio_pcie): power-controller@2e8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x2e8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -495,7 +493,7 @@
 	};
 
 	DIE_NODE(ps_atc0_cio_usb): power-controller@2f0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x2f0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -504,7 +502,7 @@
 	};
 
 	DIE_NODE(ps_atc1_cio_pcie): power-controller@2f8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x2f8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -513,7 +511,7 @@
 	};
 
 	DIE_NODE(ps_atc1_cio_usb): power-controller@300 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x300 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -522,7 +520,7 @@
 	};
 
 	DIE_NODE(ps_atc2_cio_pcie): power-controller@308 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x308 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -531,7 +529,7 @@
 	};
 
 	DIE_NODE(ps_atc2_cio_usb): power-controller@310 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x310 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -540,7 +538,7 @@
 	};
 
 	DIE_NODE(ps_atc3_cio_pcie): power-controller@318 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x318 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -549,7 +547,7 @@
 	};
 
 	DIE_NODE(ps_atc3_cio_usb): power-controller@320 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x320 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -558,7 +556,7 @@
 	};
 
 	DIE_NODE(ps_trace_fab): power-controller@390 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x390 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -566,7 +564,7 @@
 	};
 
 	DIE_NODE(ps_ane_sys_mpm): power-controller@4000 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x4000 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -575,7 +573,7 @@
 	};
 
 	DIE_NODE(ps_ane_td): power-controller@4008 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x4008 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -584,7 +582,7 @@
 	};
 
 	DIE_NODE(ps_ane_base): power-controller@4010 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x4010 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -593,7 +591,7 @@
 	};
 
 	DIE_NODE(ps_ane_set1): power-controller@4018 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x4018 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -602,7 +600,7 @@
 	};
 
 	DIE_NODE(ps_ane_set2): power-controller@4020 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x4020 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -611,7 +609,7 @@
 	};
 
 	DIE_NODE(ps_ane_set3): power-controller@4028 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x4028 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -620,7 +618,7 @@
 	};
 
 	DIE_NODE(ps_ane_set4): power-controller@4030 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x4030 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -631,7 +629,7 @@
 
 &DIE_NODE(pmgr_south) {
 	DIE_NODE(ps_amcc4): power-controller@100 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x100 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -640,7 +638,7 @@
 	};
 
 	DIE_NODE(ps_amcc5): power-controller@108 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x108 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -649,7 +647,7 @@
 	};
 
 	DIE_NODE(ps_amcc6): power-controller@110 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x110 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -658,7 +656,7 @@
 	};
 
 	DIE_NODE(ps_amcc7): power-controller@118 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x118 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -667,7 +665,7 @@
 	};
 
 	DIE_NODE(ps_dcs_16): power-controller@120 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x120 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -676,7 +674,7 @@
 	};
 
 	DIE_NODE(ps_dcs_17): power-controller@128 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x128 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -685,7 +683,7 @@
 	};
 
 	DIE_NODE(ps_dcs_18): power-controller@130 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x130 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -694,7 +692,7 @@
 	};
 
 	DIE_NODE(ps_dcs_19): power-controller@138 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x138 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -703,7 +701,7 @@
 	};
 
 	DIE_NODE(ps_dcs_20): power-controller@140 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x140 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -712,7 +710,7 @@
 	};
 
 	DIE_NODE(ps_dcs_21): power-controller@148 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x148 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -721,7 +719,7 @@
 	};
 
 	DIE_NODE(ps_dcs_22): power-controller@150 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x150 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -730,7 +728,7 @@
 	};
 
 	DIE_NODE(ps_dcs_23): power-controller@158 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x158 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -739,7 +737,7 @@
 	};
 
 	DIE_NODE(ps_dcs_24): power-controller@160 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x160 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -748,7 +746,7 @@
 	};
 
 	DIE_NODE(ps_dcs_25): power-controller@168 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x168 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -757,7 +755,7 @@
 	};
 
 	DIE_NODE(ps_dcs_26): power-controller@170 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x170 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -766,7 +764,7 @@
 	};
 
 	DIE_NODE(ps_dcs_27): power-controller@178 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x178 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -775,7 +773,7 @@
 	};
 
 	DIE_NODE(ps_dcs_28): power-controller@180 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x180 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -784,7 +782,7 @@
 	};
 
 	DIE_NODE(ps_dcs_29): power-controller@188 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x188 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -793,7 +791,7 @@
 	};
 
 	DIE_NODE(ps_dcs_30): power-controller@190 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x190 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -802,7 +800,7 @@
 	};
 
 	DIE_NODE(ps_dcs_31): power-controller@198 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x198 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -811,7 +809,7 @@
 	};
 
 	DIE_NODE(ps_afnc4_ioa): power-controller@1a0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1a0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -821,7 +819,7 @@
 	};
 
 	DIE_NODE(ps_afnc4_ls): power-controller@1a8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1a8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -831,7 +829,7 @@
 	};
 
 	DIE_NODE(ps_afnc4_lw0): power-controller@1b0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1b0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -841,7 +839,7 @@
 	};
 
 	DIE_NODE(ps_afnc5_ioa): power-controller@1b8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1b8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -851,7 +849,7 @@
 	};
 
 	DIE_NODE(ps_afnc5_ls): power-controller@1c0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1c0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -861,7 +859,7 @@
 	};
 
 	DIE_NODE(ps_afnc5_lw0): power-controller@1c8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1c8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -871,7 +869,7 @@
 	};
 
 	DIE_NODE(ps_dispext2_sys): power-controller@1d0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1d0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -879,7 +877,7 @@
 	};
 
 	DIE_NODE(ps_msr1): power-controller@1d8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1d8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -887,7 +885,7 @@
 	};
 
 	DIE_NODE(ps_dispext2_fe): power-controller@1e0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1e0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -896,7 +894,7 @@
 	};
 
 	DIE_NODE(ps_dispext2_cpu0): power-controller@1e8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1e8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -906,7 +904,7 @@
 	};
 
 	DIE_NODE(ps_msr1_ase_core): power-controller@1f0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1f0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -915,7 +913,7 @@
 	};
 
 	DIE_NODE(ps_dispext3_sys): power-controller@220 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x220 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -923,7 +921,7 @@
 	};
 
 	DIE_NODE(ps_venc1_sys): power-controller@228 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x228 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -931,7 +929,7 @@
 	};
 
 	DIE_NODE(ps_dispext3_fe): power-controller@230 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x230 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -940,7 +938,7 @@
 	};
 
 	DIE_NODE(ps_dispext3_cpu0): power-controller@238 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x238 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -950,7 +948,7 @@
 	};
 
 	DIE_NODE(ps_venc1_dma): power-controller@4000 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x4000 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -959,7 +957,7 @@
 	};
 
 	DIE_NODE(ps_venc1_pipe4): power-controller@4008 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x4008 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -968,7 +966,7 @@
 	};
 
 	DIE_NODE(ps_venc1_pipe5): power-controller@4010 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x4010 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -977,7 +975,7 @@
 	};
 
 	DIE_NODE(ps_venc1_me0): power-controller@4018 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x4018 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -986,7 +984,7 @@
 	};
 
 	DIE_NODE(ps_venc1_me1): power-controller@4020 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x4020 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -997,7 +995,7 @@
 
 &DIE_NODE(pmgr_east) {
 	DIE_NODE(ps_clvr_spmi0): power-controller@100 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x100 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1006,7 +1004,7 @@
 	};
 
 	DIE_NODE(ps_clvr_spmi1): power-controller@108 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x108 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1015,7 +1013,7 @@
 	};
 
 	DIE_NODE(ps_clvr_spmi2): power-controller@110 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x110 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1024,7 +1022,7 @@
 	};
 
 	DIE_NODE(ps_clvr_spmi3): power-controller@118 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x118 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1033,7 +1031,7 @@
 	};
 
 	DIE_NODE(ps_clvr_spmi4): power-controller@120 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x120 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1042,7 +1040,7 @@
 	};
 
 	DIE_NODE(ps_ispsens0): power-controller@128 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x128 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1050,7 +1048,7 @@
 	};
 
 	DIE_NODE(ps_ispsens1): power-controller@130 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x130 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1058,7 +1056,7 @@
 	};
 
 	DIE_NODE(ps_ispsens2): power-controller@138 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x138 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1066,7 +1064,7 @@
 	};
 
 	DIE_NODE(ps_ispsens3): power-controller@140 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x140 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1074,7 +1072,7 @@
 	};
 
 	DIE_NODE(ps_afnc6_ioa): power-controller@148 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x148 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1084,7 +1082,7 @@
 	};
 
 	DIE_NODE(ps_afnc6_ls): power-controller@150 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x150 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1094,7 +1092,7 @@
 	};
 
 	DIE_NODE(ps_afnc6_lw0): power-controller@158 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x158 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1104,7 +1102,7 @@
 	};
 
 	DIE_NODE(ps_afnc2_ioa): power-controller@160 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x160 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1114,7 +1112,7 @@
 	};
 
 	DIE_NODE(ps_afnc2_ls): power-controller@168 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x168 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1124,7 +1122,7 @@
 	};
 
 	DIE_NODE(ps_afnc2_lw0): power-controller@170 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x170 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1134,7 +1132,7 @@
 	};
 
 	DIE_NODE(ps_afnc2_lw1): power-controller@178 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x178 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1144,7 +1142,7 @@
 	};
 
 	DIE_NODE(ps_afnc3_ioa): power-controller@180 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x180 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1154,7 +1152,7 @@
 	};
 
 	DIE_NODE(ps_afnc3_ls): power-controller@188 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x188 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1164,7 +1162,7 @@
 	};
 
 	DIE_NODE(ps_afnc3_lw0): power-controller@190 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x190 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1174,7 +1172,7 @@
 	};
 
 	DIE_NODE(ps_apcie_gp): power-controller@198 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x198 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1183,7 +1181,7 @@
 	};
 
 	DIE_NODE(ps_apcie_st): power-controller@1a0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1a0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1192,7 +1190,7 @@
 	};
 
 	DIE_NODE(ps_ans2): power-controller@1a8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1a8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1201,7 +1199,7 @@
 	};
 
 	DIE_NODE(ps_disp0_sys): power-controller@1b0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1b0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1210,7 +1208,7 @@
 	};
 
 	DIE_NODE(ps_jpg): power-controller@1b8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1b8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1219,7 +1217,7 @@
 	};
 
 	DIE_NODE(ps_sio): power-controller@1c0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1c0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1228,7 +1226,7 @@
 	};
 
 	DIE_NODE(ps_isp_sys): power-controller@1c8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1c8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1238,7 +1236,7 @@
 	};
 
 	DIE_NODE(ps_disp0_fe): power-controller@1d0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1d0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1247,7 +1245,7 @@
 	};
 
 	DIE_NODE(ps_disp0_cpu0): power-controller@1d8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1d8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1257,16 +1255,16 @@
 	};
 
 	DIE_NODE(ps_sio_cpu): power-controller@1e0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1e0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
 		label = DIE_LABEL(sio_cpu);
-		power-domains = <&DIE_NODE(ps_sio)>;
+		power-domains = <&DIE_NODE(ps_sio) &DIE_NODE(ps_uart_p) &DIE_NODE(ps_spi_p) &DIE_NODE(ps_audio_p)>;
 	};
 
 	DIE_NODE(ps_fpwm0): power-controller@1e8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1e8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1275,7 +1273,7 @@
 	};
 
 	DIE_NODE(ps_fpwm1): power-controller@1f0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1f0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1284,7 +1282,7 @@
 	};
 
 	DIE_NODE(ps_fpwm2): power-controller@1f8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x1f8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1293,7 +1291,7 @@
 	};
 
 	DIE_NODE(ps_i2c0): power-controller@200 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x200 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1302,7 +1300,7 @@
 	};
 
 	DIE_NODE(ps_i2c1): power-controller@208 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x208 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1311,7 +1309,7 @@
 	};
 
 	DIE_NODE(ps_i2c2): power-controller@210 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x210 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1320,7 +1318,7 @@
 	};
 
 	DIE_NODE(ps_i2c3): power-controller@218 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x218 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1329,7 +1327,7 @@
 	};
 
 	DIE_NODE(ps_i2c4): power-controller@220 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x220 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1338,7 +1336,7 @@
 	};
 
 	DIE_NODE(ps_i2c5): power-controller@228 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x228 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1347,7 +1345,7 @@
 	};
 
 	DIE_NODE(ps_i2c6): power-controller@230 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x230 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1356,7 +1354,7 @@
 	};
 
 	DIE_NODE(ps_i2c7): power-controller@238 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x238 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1365,7 +1363,7 @@
 	};
 
 	DIE_NODE(ps_i2c8): power-controller@240 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x240 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1374,7 +1372,7 @@
 	};
 
 	DIE_NODE(ps_spi_p): power-controller@248 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x248 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1383,7 +1381,7 @@
 	};
 
 	DIE_NODE(ps_sio_spmi0): power-controller@250 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x250 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1392,7 +1390,7 @@
 	};
 
 	DIE_NODE(ps_sio_spmi1): power-controller@258 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x258 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1401,7 +1399,7 @@
 	};
 
 	DIE_NODE(ps_sio_spmi2): power-controller@260 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x260 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1410,7 +1408,7 @@
 	};
 
 	DIE_NODE(ps_uart_p): power-controller@268 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x268 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1419,7 +1417,7 @@
 	};
 
 	DIE_NODE(ps_audio_p): power-controller@270 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x270 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1428,7 +1426,7 @@
 	};
 
 	DIE_NODE(ps_sio_adma): power-controller@278 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x278 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1437,7 +1435,7 @@
 	};
 
 	DIE_NODE(ps_aes): power-controller@280 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x280 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1447,7 +1445,7 @@
 	};
 
 	DIE_NODE(ps_dptx_phy_ps): power-controller@288 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x288 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1456,7 +1454,7 @@
 	};
 
 	DIE_NODE(ps_spi0): power-controller@2d8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x2d8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1465,7 +1463,7 @@
 	};
 
 	DIE_NODE(ps_spi1): power-controller@2e0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x2e0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1474,7 +1472,7 @@
 	};
 
 	DIE_NODE(ps_spi2): power-controller@2e8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x2e8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1483,7 +1481,7 @@
 	};
 
 	DIE_NODE(ps_spi3): power-controller@2f0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x2f0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1492,7 +1490,7 @@
 	};
 
 	DIE_NODE(ps_spi4): power-controller@2f8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x2f8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1501,7 +1499,7 @@
 	};
 
 	DIE_NODE(ps_spi5): power-controller@300 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x300 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1510,7 +1508,7 @@
 	};
 
 	DIE_NODE(ps_uart_n): power-controller@308 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x308 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1519,7 +1517,7 @@
 	};
 
 	DIE_NODE(ps_uart0): power-controller@310 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x310 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1528,7 +1526,7 @@
 	};
 
 	DIE_NODE(ps_amcc1): power-controller@318 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x318 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1537,7 +1535,7 @@
 	};
 
 	DIE_NODE(ps_amcc3): power-controller@320 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x320 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1546,7 +1544,7 @@
 	};
 
 	DIE_NODE(ps_dcs_04): power-controller@328 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x328 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1555,7 +1553,7 @@
 	};
 
 	DIE_NODE(ps_dcs_05): power-controller@330 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x330 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1564,7 +1562,7 @@
 	};
 
 	DIE_NODE(ps_dcs_06): power-controller@338 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x338 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1573,7 +1571,7 @@
 	};
 
 	DIE_NODE(ps_dcs_07): power-controller@340 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x340 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1582,7 +1580,7 @@
 	};
 
 	DIE_NODE(ps_dcs_12): power-controller@348 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x348 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1591,7 +1589,7 @@
 	};
 
 	DIE_NODE(ps_dcs_13): power-controller@350 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x350 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1600,7 +1598,7 @@
 	};
 
 	DIE_NODE(ps_dcs_14): power-controller@358 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x358 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1609,7 +1607,7 @@
 	};
 
 	DIE_NODE(ps_dcs_15): power-controller@360 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x360 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1618,7 +1616,7 @@
 	};
 
 	DIE_NODE(ps_uart1): power-controller@368 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x368 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1627,7 +1625,7 @@
 	};
 
 	DIE_NODE(ps_uart2): power-controller@370 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x370 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1636,7 +1634,7 @@
 	};
 
 	DIE_NODE(ps_uart3): power-controller@378 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x378 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1645,7 +1643,7 @@
 	};
 
 	DIE_NODE(ps_uart4): power-controller@380 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x380 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1654,7 +1652,7 @@
 	};
 
 	DIE_NODE(ps_uart5): power-controller@388 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x388 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1663,7 +1661,7 @@
 	};
 
 	DIE_NODE(ps_uart6): power-controller@390 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x390 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1672,7 +1670,7 @@
 	};
 
 	DIE_NODE(ps_mca0): power-controller@398 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x398 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1682,7 +1680,7 @@
 	};
 
 	DIE_NODE(ps_mca1): power-controller@3a0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x3a0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1692,7 +1690,7 @@
 	};
 
 	DIE_NODE(ps_mca2): power-controller@3a8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x3a8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1702,7 +1700,7 @@
 	};
 
 	DIE_NODE(ps_mca3): power-controller@3b0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x3b0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1712,7 +1710,7 @@
 	};
 
 	DIE_NODE(ps_dpa0): power-controller@3b8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x3b8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1721,7 +1719,7 @@
 	};
 
 	DIE_NODE(ps_dpa1): power-controller@3c0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x3c0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1730,7 +1728,7 @@
 	};
 
 	DIE_NODE(ps_dpa2): power-controller@3c8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x3c8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1739,7 +1737,7 @@
 	};
 
 	DIE_NODE(ps_dpa3): power-controller@3d0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x3d0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1748,7 +1746,7 @@
 	};
 
 	DIE_NODE(ps_msr0): power-controller@3d8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x3d8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1756,7 +1754,7 @@
 	};
 
 	DIE_NODE(ps_venc_sys): power-controller@3e0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x3e0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1764,7 +1762,7 @@
 	};
 
 	DIE_NODE(ps_dpa4): power-controller@3e8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x3e8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1773,7 +1771,7 @@
 	};
 
 	DIE_NODE(ps_msr0_ase_core): power-controller@3f0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x3f0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1782,7 +1780,7 @@
 	};
 
 	DIE_NODE(ps_apcie_gpshr_sys): power-controller@3f8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x3f8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1791,7 +1789,7 @@
 	};
 
 	DIE_NODE(ps_apcie_st_sys): power-controller@408 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x408 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1800,7 +1798,7 @@
 	};
 
 	DIE_NODE(ps_apcie_st1_sys): power-controller@410 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x410 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1809,7 +1807,7 @@
 	};
 
 	DIE_NODE(ps_apcie_gp_sys): power-controller@418 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x418 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1819,7 +1817,7 @@
 	};
 
 	DIE_NODE(ps_apcie_ge_sys): power-controller@420 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x420 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1828,7 +1826,7 @@
 	};
 
 	DIE_NODE(ps_apcie_phy_sw): power-controller@428 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x428 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1837,7 +1835,7 @@
 	};
 
 	DIE_NODE(ps_sep): power-controller@c00 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0xc00 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1854,7 +1852,7 @@
 	 * have to enable/disable everything in the per-model DTs.
 	 */
 	DIE_NODE(ps_isp_cpu): power-controller@4000 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x4000 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1864,7 +1862,7 @@
 	};
 
 	DIE_NODE(ps_isp_fe): power-controller@4008 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x4008 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1873,7 +1871,7 @@
 	};
 
 	DIE_NODE(ps_dprx): power-controller@4010 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x4010 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1882,7 +1880,7 @@
 	};
 
 	DIE_NODE(ps_isp_vis): power-controller@4018 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x4018 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1891,7 +1889,7 @@
 	};
 
 	DIE_NODE(ps_isp_be): power-controller@4020 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x4020 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1900,7 +1898,7 @@
 	};
 
 	DIE_NODE(ps_isp_raw): power-controller@4028 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x4028 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1909,7 +1907,7 @@
 	};
 
 	DIE_NODE(ps_isp_clr): power-controller@4030 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x4030 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1918,7 +1916,7 @@
 	};
 
 	DIE_NODE(ps_venc_dma): power-controller@8000 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x8000 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1927,7 +1925,7 @@
 	};
 
 	DIE_NODE(ps_venc_pipe4): power-controller@8008 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x8008 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1936,7 +1934,7 @@
 	};
 
 	DIE_NODE(ps_venc_pipe5): power-controller@8010 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x8010 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1945,7 +1943,7 @@
 	};
 
 	DIE_NODE(ps_venc_me0): power-controller@8018 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x8018 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1954,7 +1952,7 @@
 	};
 
 	DIE_NODE(ps_venc_me1): power-controller@8020 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x8020 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1963,7 +1961,7 @@
 	};
 
 	DIE_NODE(ps_prores): power-controller@c000 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0xc000 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1974,7 +1972,7 @@
 
 &DIE_NODE(pmgr_mini) {
 	DIE_NODE(ps_debug): power-controller@58 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x58 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1983,7 +1981,7 @@
 	};
 
 	DIE_NODE(ps_nub_spmi0): power-controller@60 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x60 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -1992,7 +1990,7 @@
 	};
 
 	DIE_NODE(ps_nub_spmi1): power-controller@68 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x68 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2001,7 +1999,7 @@
 	};
 
 	DIE_NODE(ps_nub_aon): power-controller@70 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x70 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2010,7 +2008,7 @@
 	};
 
 	DIE_NODE(ps_msg): power-controller@78 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x78 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2019,7 +2017,7 @@
 	};
 
 	DIE_NODE(ps_nub_gpio): power-controller@80 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x80 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2028,7 +2026,7 @@
 	};
 
 	DIE_NODE(ps_nub_fabric): power-controller@88 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x88 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2037,7 +2035,7 @@
 	};
 
 	DIE_NODE(ps_atc0_usb_aon): power-controller@90 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x90 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2046,7 +2044,7 @@
 	};
 
 	DIE_NODE(ps_atc1_usb_aon): power-controller@98 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x98 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2055,7 +2053,7 @@
 	};
 
 	DIE_NODE(ps_atc2_usb_aon): power-controller@a0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0xa0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2064,7 +2062,7 @@
 	};
 
 	DIE_NODE(ps_atc3_usb_aon): power-controller@a8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0xa8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2073,7 +2071,7 @@
 	};
 
 	DIE_NODE(ps_mtp_fabric): power-controller@b0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0xb0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2084,7 +2082,7 @@
 	};
 
 	DIE_NODE(ps_nub_sram): power-controller@b8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0xb8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2093,7 +2091,7 @@
 	};
 
 	DIE_NODE(ps_debug_switch): power-controller@c0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0xc0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2102,7 +2100,7 @@
 	};
 
 	DIE_NODE(ps_atc0_usb): power-controller@c8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0xc8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2111,7 +2109,7 @@
 	};
 
 	DIE_NODE(ps_atc1_usb): power-controller@d0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0xd0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2120,7 +2118,7 @@
 	};
 
 	DIE_NODE(ps_atc2_usb): power-controller@d8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0xd8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2129,7 +2127,7 @@
 	};
 
 	DIE_NODE(ps_atc3_usb): power-controller@e0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0xe0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2140,7 +2138,7 @@
 #if 0
 	/* MTP stuff is self-managed */
 	DIE_NODE(ps_mtp_gpio): power-controller@e8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0xe8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2150,7 +2148,7 @@
 	};
 
 	DIE_NODE(ps_mtp_base): power-controller@f0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0xf0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2160,7 +2158,7 @@
 	};
 
 	DIE_NODE(ps_mtp_periph): power-controller@f8 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0xf8 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2170,7 +2168,7 @@
 	};
 
 	DIE_NODE(ps_mtp_spi0): power-controller@100 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x100 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2180,7 +2178,7 @@
 	};
 
 	DIE_NODE(ps_mtp_i2cm0): power-controller@108 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x108 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2190,7 +2188,7 @@
 	};
 
 	DIE_NODE(ps_mtp_uart0): power-controller@110 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x110 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2200,7 +2198,7 @@
 	};
 
 	DIE_NODE(ps_mtp_cpu): power-controller@118 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x118 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2210,7 +2208,7 @@
 	};
 
 	DIE_NODE(ps_mtp_scm_fabric): power-controller@120 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x120 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2220,7 +2218,7 @@
 	};
 
 	DIE_NODE(ps_mtp_sram): power-controller@128 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x128 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2230,7 +2228,7 @@
 	};
 
 	DIE_NODE(ps_mtp_dma): power-controller@130 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x130 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2243,7 +2241,7 @@
 
 &DIE_NODE(pmgr_gfx) {
 	DIE_NODE(ps_gpx): power-controller@0 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x0 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2253,7 +2251,7 @@
 	};
 
 	DIE_NODE(ps_afr): power-controller@100 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x100 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2263,7 +2261,7 @@
 	};
 
 	DIE_NODE(ps_gfx): power-controller@108 {
-		compatible = "apple,t6020-pmgr-pwrstate", "apple,pmgr-pwrstate";
+		compatible = "apple,t6020-pmgr-pwrstate", "apple,t8103-pmgr-pwrstate", "apple,pmgr-pwrstate";
 		reg = <0x108 4>;
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
@@ -2271,4 +2269,3 @@
 		power-domains = <&DIE_NODE(ps_afr)>, <&DIE_NODE(ps_gpx)>;
 	};
 };
-

--- a/arch/arm/dts/t8103-j274.dts
+++ b/arch/arm/dts/t8103-j274.dts
@@ -15,14 +15,25 @@
 / {
 	compatible = "apple,j274", "apple,t8103", "apple,arm-platform";
 	model = "Apple Mac mini (M1, 2020)";
+	chassis-type = "desktop";
 
 	aliases {
 		ethernet0 = &ethernet0;
+		sio = &sio;
 	};
 };
 
 &dcp {
 	apple,connector-type = "HDMI-A";
+};
+
+/* remove once m1n1 enables sio nodes after setup */
+&sio {
+        status = "okay";
+};
+
+&dpaudio0 {
+	status = "okay";
 };
 
 &bluetooth0 {
@@ -134,3 +145,5 @@
 &gpu {
 	apple,perf-base-pstate = <3>;
 };
+
+#include "hwmon-mini.dtsi"

--- a/arch/arm/dts/t8103-j293.dts
+++ b/arch/arm/dts/t8103-j293.dts
@@ -16,6 +16,16 @@
 / {
 	compatible = "apple,j293", "apple,t8103", "apple,arm-platform";
 	model = "Apple MacBook Pro (13-inch, M1, 2020)";
+	chassis-type = "laptop";
+
+	/*
+	 * All of those are used by the bootloader to pass calibration
+	 * blobs and other device-specific properties
+	 */
+	aliases {
+		touchbar0 = &touchbar0;
+		sep = &sep;
+	};
 
 	led-controller {
 		compatible = "pwm-leds";
@@ -28,10 +38,6 @@
 			default-state = "keep";
 		};
 	};
-
-	aliases {
-		touchbar0 = &touchbar0;
-	};
 };
 
 &dcp {
@@ -41,6 +47,11 @@
 		height-mm = <179>;
 		apple,max-brightness = <525>;
 	};
+};
+
+&framebuffer0 {
+	panel = <&panel>;
+	post-init-providers = <&panel>;
 };
 
 &bluetooth0 {
@@ -61,26 +72,6 @@
 
 &typec1 {
 	label = "USB-C Left-front";
-};
-
-&spi0 {
-	status = "okay";
-
-	touchbar0: touchbar@0 {
-		compatible = "apple,j293-touchbar",
-			"apple,z2-touchbar", "apple,z2-multitouch";
-		reg = <0>;
-		spi-max-frequency = <11500000>;
-		spi-cs-setup-delay-ns = <2000>;
-		spi-cs-hold-delay-ns = <2000>;
-		reset-gpios = <&pinctrl_ap 139 GPIO_ACTIVE_LOW>;
-		cs-gpios = <&pinctrl_ap 109 0>;
-		interrupts-extended = <&pinctrl_ap 194 IRQ_TYPE_EDGE_FALLING>;
-		firmware-name = "apple/dfrmtfw-j293.bin";
-		touchscreen-size-x = <23045>;
-		touchscreen-size-y = <640>;
-		label = "MacBookPro17,1 Touch Bar";
-	};
 };
 
 &spi3 {
@@ -192,12 +183,91 @@
 	status = "okay";
 };
 
+&spi0 {
+	cs-gpios = <&pinctrl_ap 109 GPIO_ACTIVE_LOW>;
+	status = "okay";
+
+	touchbar0: touchbar@0 {
+		compatible = "apple,j293-touchbar";
+		reg = <0>;
+		spi-max-frequency = <11500000>;
+		spi-cs-setup-delay-ns = <2000>;
+		spi-cs-hold-delay-ns = <2000>;
+		reset-gpios = <&pinctrl_ap 139 GPIO_ACTIVE_LOW>;
+		interrupts-extended = <&pinctrl_ap 194 IRQ_TYPE_EDGE_FALLING>;
+		firmware-name = "apple/dfrmtfw-j293.bin";
+		touchscreen-size-x = <23045>;
+		touchscreen-size-y = <640>;
+		touchscreen-inverted-y;
+	};
+};
+
+/*
+ * The driver depends on boot loader initialized state which resets when this
+ * power-domain is powered off. This happens on suspend or when the driver is
+ * missing during boot. Mark the domain as always on until the driver can
+ * handle this.
+ */
+&ps_dispdfr_be {
+	apple,always-on;
+};
+
 &display_dfr {
 	status = "okay";
-	dfr_panel: panel@0 {
-		compatible = "apple,summit";
+};
+
+&dfr_mipi_out {
+	dfr_mipi_out_panel: endpoint@0 {
 		reg = <0>;
+		remote-endpoint = <&dfr_panel_in>;
 	};
+};
+
+&displaydfr_mipi {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	dfr_panel: panel@0 {
+		compatible = "apple,j293-summit", "apple,summit";
+		reg = <0>;
+		max-brightness = <255>;
+
+		port {
+			dfr_panel_in: endpoint {
+				remote-endpoint = <&dfr_mipi_out_panel>;
+			};
+		};
+	};
+};
+
+&displaydfr_dart {
+	status = "okay";
+};
+
+&aop_mbox {
+       status = "okay";
+};
+
+&aop_dart {
+       status = "okay";
+};
+
+&aop_admac {
+       status = "okay";
+};
+
+&aop {
+	status = "okay";
+};
+
+&sep {
+	status = "okay";
+};
+
+&aop_audio {
+	apple,chassis-name = "J293";
+	apple,machine-kind = "MacBook Pro";
 };
 
 / {
@@ -235,3 +305,6 @@
 &isp {
 	apple,platform-id = <1>;
 };
+
+#include "hwmon-fan.dtsi"
+#include "hwmon-laptop.dtsi"

--- a/arch/arm/dts/t8103-j313.dts
+++ b/arch/arm/dts/t8103-j313.dts
@@ -16,6 +16,11 @@
 / {
 	compatible = "apple,j313", "apple,t8103", "apple,arm-platform";
 	model = "Apple MacBook Air (M1, 2020)";
+	chassis-type = "laptop";
+
+	aliases {
+		sep = &sep;
+	};
 
 	led-controller {
 		compatible = "pwm-leds";
@@ -37,6 +42,11 @@
 		height-mm = <179>;
 		apple,max-brightness = <420>;
 	};
+};
+
+&framebuffer0 {
+	panel = <&panel>;
+	post-init-providers = <&panel>;
 };
 
 &bluetooth0 {
@@ -134,6 +144,31 @@
 	};
 };
 
+&aop_mbox {
+       status = "okay";
+};
+
+&aop_dart {
+       status = "okay";
+};
+
+&aop_admac {
+       status = "okay";
+};
+
+&aop {
+	status = "okay";
+};
+
+&sep {
+	status = "okay";
+};
+
+&aop_audio {
+	apple,chassis-name = "J313";
+	apple,machine-kind = "MacBook Air";
+};
+
 / {
 	sound {
 		compatible = "apple,j313-macaudio", "apple,macaudio";
@@ -168,3 +203,5 @@
 &isp {
 	apple,platform-id = <1>;
 };
+
+#include "hwmon-laptop.dtsi"

--- a/arch/arm/dts/t8103-j456.dts
+++ b/arch/arm/dts/t8103-j456.dts
@@ -15,6 +15,7 @@
 / {
 	compatible = "apple,j456", "apple,t8103", "apple,arm-platform";
 	model = "Apple iMac (24-inch, 4x USB-C, M1, 2021)";
+	chassis-type = "all-in-one";
 
 	aliases {
 		ethernet0 = &ethernet0;
@@ -28,6 +29,11 @@
 		height-mm = <294>;
 		apple,max-brightness = <525>;
 	};
+};
+
+&framebuffer0 {
+	panel = <&panel>;
+	post-init-providers = <&panel>;
 };
 
 &bluetooth0 {
@@ -110,6 +116,32 @@
 	};
 };
 
+&aop_mbox {
+       status = "okay";
+};
+
+&aop_dart {
+       status = "okay";
+};
+
+&aop_admac {
+       status = "okay";
+};
+
+&aop {
+	status = "okay";
+};
+
+&sep {
+	status = "okay";
+};
+
+&aop_audio {
+	apple,chassis-name = "J456";
+	apple,machine-kind = "iMac";
+	apple,no-beamforming;
+};
+
 / {
 	sound {
 		compatible = "apple,j456-macaudio", "apple,macaudio";
@@ -137,3 +169,5 @@
 &isp {
 	apple,platform-id = <2>;
 };
+
+#include "hwmon-fan-dual.dtsi"

--- a/arch/arm/dts/t8103-j457.dts
+++ b/arch/arm/dts/t8103-j457.dts
@@ -15,6 +15,7 @@
 / {
 	compatible = "apple,j457", "apple,t8103", "apple,arm-platform";
 	model = "Apple iMac (24-inch, 2x USB-C, M1, 2021)";
+	chassis-type = "all-in-one";
 
 	aliases {
 		ethernet0 = &ethernet0;
@@ -28,6 +29,19 @@
 		height-mm = <294>;
 		apple,max-brightness = <525>;
 	};
+};
+
+&framebuffer0 {
+	panel = <&panel>;
+	post-init-providers = <&panel>;
+};
+
+/*
+ * Adjust pcie0's iommu-map to account for the disabled port01.
+ */
+&pcie0 {
+	iommu-map = <0x100 &pcie0_dart_0 1 1>,
+			<0x200 &pcie0_dart_2 1 1>;
 };
 
 &bluetooth0 {
@@ -57,10 +71,10 @@
  */
 
 &port02 {
-	bus-range = <3 3>;
+	bus-range = <2 2>;
 	status = "okay";
 	ethernet0: ethernet@0,0 {
-		reg = <0x30000 0x0 0x0 0x0 0x0>;
+		reg = <0x20000 0x0 0x0 0x0 0x0>;
 		/* To be filled by the loader */
 		local-mac-address = [00 10 18 00 00 00];
 	};
@@ -81,6 +95,32 @@
 		cirrus,ts-inv = <1>;
 		sound-name-prefix = "Jack";
 	};
+};
+
+&aop_mbox {
+       status = "okay";
+};
+
+&aop_dart {
+       status = "okay";
+};
+
+&aop_admac {
+       status = "okay";
+};
+
+&aop {
+	status = "okay";
+};
+
+&sep {
+	status = "okay";
+};
+
+&aop_audio {
+	apple,chassis-name = "J457";
+	apple,machine-kind = "iMac";
+	apple,no-beamforming;
 };
 
 / {
@@ -110,3 +150,5 @@
 &isp {
 	apple,platform-id = <2>;
 };
+
+#include "hwmon-fan.dtsi"

--- a/arch/arm/dts/t8103-jxxx.dtsi
+++ b/arch/arm/dts/t8103-jxxx.dtsi
@@ -15,7 +15,6 @@
 		dcp = &dcp;
 		disp0 = &display;
 		disp0_piodma = &disp0_piodma;
-		nvram = &nvram;
 		serial0 = &serial0;
 		serial2 = &serial2;
 		wifi0 = &wifi0;
@@ -78,14 +77,14 @@
 				#size-cells = <0>;
 				port@0 {
 					reg = <0>;
-					typec0_con_hs: endpoint {
-						remote-endpoint = <&typec0_usb_hs>;
+					typec0_connector_hs: endpoint {
+						remote-endpoint = <&dwc3_0_hs>;
 					};
 				};
 				port@1 {
 					reg = <1>;
-					typec0_con_ss: endpoint {
-						remote-endpoint = <&typec0_usb_ss>;
+					typec0_connector_ss: endpoint {
+						remote-endpoint = <&atcphy0_typec_lanes>;
 					};
 				};
 			};
@@ -109,14 +108,14 @@
 				#size-cells = <0>;
 				port@0 {
 					reg = <0>;
-					typec1_con_hs: endpoint {
-						remote-endpoint = <&typec1_usb_hs>;
+					typec1_connector_hs: endpoint {
+						remote-endpoint = <&dwc3_1_hs>;
 					};
 				};
 				port@1 {
 					reg = <1>;
-					typec1_con_ss: endpoint {
-						remote-endpoint = <&typec1_usb_ss>;
+					typec1_connector_ss: endpoint {
+						remote-endpoint = <&atcphy1_typec_lanes>;
 					};
 				};
 			};
@@ -126,34 +125,86 @@
 
 /* USB controllers */
 &dwc3_0 {
-	port {
-		typec0_usb_hs: endpoint {
-			remote-endpoint = <&typec0_con_hs>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			dwc3_0_hs: endpoint {
+				remote-endpoint = <&typec0_connector_hs>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			dwc3_0_ss: endpoint {
+				remote-endpoint = <&atcphy0_usb3>;
+			};
 		};
 	};
 };
 
 &dwc3_1 {
-	port {
-		typec1_usb_hs: endpoint {
-			remote-endpoint = <&typec1_con_hs>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			dwc3_1_hs: endpoint {
+				remote-endpoint = <&typec1_connector_hs>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			dwc3_1_ss: endpoint {
+				remote-endpoint = <&atcphy1_usb3>;
+			};
 		};
 	};
 };
 
 /* Type-C PHYs */
 &atcphy0 {
-	port {
-		typec0_usb_ss: endpoint {
-			remote-endpoint = <&typec0_con_ss>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			atcphy0_typec_lanes: endpoint {
+				remote-endpoint = <&typec0_connector_ss>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			atcphy0_usb3: endpoint {
+				remote-endpoint = <&dwc3_0_ss>;
+			};
 		};
 	};
 };
 
 &atcphy1 {
-	port {
-		typec1_usb_ss: endpoint {
-			remote-endpoint = <&typec1_con_ss>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			atcphy1_typec_lanes: endpoint {
+				remote-endpoint = <&typec1_connector_ss>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			atcphy1_usb3: endpoint {
+				remote-endpoint = <&dwc3_1_ss>;
+			};
 		};
 	};
 };
@@ -166,7 +217,7 @@
 &port00 {
 	bus-range = <1 1>;
 	pwren-gpios = <&smc_gpio 13 GPIO_ACTIVE_HIGH>;
-	wifi0: network@0,0 {
+	wifi0: wifi@0,0 {
 		compatible = "pci14e4,4425";
 		reg = <0x10000 0x0 0x0 0x0 0x0>;
 		/* To be filled by the loader */
@@ -185,5 +236,7 @@
 &nco_clkref {
 	clock-frequency = <900000000>;
 };
+
+#include "hwmon-common.dtsi"
 
 #include "spi1-nvram.dtsi"

--- a/arch/arm/dts/t8103-pmgr.dtsi
+++ b/arch/arm/dts/t8103-pmgr.dtsi
@@ -234,7 +234,7 @@
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
 		label = "sio_cpu";
-		power-domains = <&ps_sio>;
+		power-domains = <&ps_sio &ps_uart_p &ps_spi_p &ps_dpa0>;
 	};
 
 	ps_fpwm0: power-controller@1d8 {

--- a/arch/arm/dts/t8103.dtsi
+++ b/arch/arm/dts/t8103.dtsi
@@ -439,19 +439,28 @@
 		#size-cells = <2>;
 		ranges;
 
+		gpu_globals: globals {
+			status = "disabled";
+		};
+
+		gpu_hw_cal_a: hw-cal-a {
+			status = "disabled";
+		};
+
+		gpu_hw_cal_b: hw-cal-b {
+			status = "disabled";
+		};
+
 		uat_handoff: uat-handoff {
 			reg = <0 0 0 0>;
-			no-map;
 		};
 
 		uat_pagetables: uat-pagetables {
 			reg = <0 0 0 0>;
-			no-map;
 		};
 
 		uat_ttbs: uat-ttbs {
 			reg = <0 0 0 0>;
-			no-map;
 		};
 	};
 
@@ -470,16 +479,14 @@
 			reg = <0x2 0x6400000 0 0x40000>,
 				<0x2 0x4000000 0 0x1000000>;
 			reg-names = "asc", "sgx";
-			interrupt-parent = <&aic>;
-			interrupts = <AIC_IRQ 563 IRQ_TYPE_LEVEL_HIGH>,
-				<AIC_IRQ 564 IRQ_TYPE_LEVEL_HIGH>,
-				<AIC_IRQ 565 IRQ_TYPE_LEVEL_HIGH>,
-				<AIC_IRQ 566 IRQ_TYPE_LEVEL_HIGH>,
-				<AIC_IRQ 579 IRQ_TYPE_LEVEL_HIGH>;
 			mboxes = <&agx_mbox>;
 			power-domains = <&ps_gfx>;
-			memory-region = <&uat_ttbs>, <&uat_pagetables>, <&uat_handoff>;
-			memory-region-names = "ttbs", "pagetables", "handoff";
+			memory-region = <&uat_ttbs>, <&uat_pagetables>, <&uat_handoff>,
+					<&gpu_hw_cal_a>, <&gpu_hw_cal_b>, <&gpu_globals>;
+			memory-region-names = "ttbs", "pagetables", "handoff",
+					      "hw-cal-a", "hw-cal-b", "globals";
+
+			apple,firmware-abi = <0 0 0>;
 
 			apple,firmware-version = <12 3 0>;
 			apple,firmware-compat = <12 3 0>;
@@ -543,19 +550,22 @@
 
 		display_dfr: display-pipe@228200000 {
 			compatible = "apple,t8103-display-pipe", "apple,h7-display-pipe";
-			reg-names = "be", "fe", "mipi";
 			reg = <0x2 0x28200000 0x0 0xc000>,
-				<0x2 0x28400000 0x0 0x4000>,
-				<0x2 0x28600000 0x0 0x100000>;
-			power-domains = <&ps_dispdfr_fe>, <&ps_dispdfr_be>, <&ps_mipi_dsi>;
+			      <0x2 0x28400000 0x0 0x4000>;
+			reg-names = "be", "fe";
+			power-domains = <&ps_dispdfr_fe>, <&ps_dispdfr_be>;
 			interrupt-parent = <&aic>;
 			interrupts = <AIC_IRQ 502 IRQ_TYPE_LEVEL_HIGH>,
-				<AIC_IRQ 506 IRQ_TYPE_LEVEL_HIGH>;
+				     <AIC_IRQ 506 IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-names = "be", "fe";
-			status = "disabled";
 			iommus = <&displaydfr_dart 0>;
-			#address-cells = <1>;
-			#size-cells = <0>;
+			status = "disabled";
+
+			port {
+				dfr_adp_out_mipi: endpoint {
+					remote-endpoint = <&dfr_mipi_in_adp>;
+				};
+			};
 		};
 
 		displaydfr_dart: iommu@228304000 {
@@ -565,6 +575,36 @@
 			interrupts = <AIC_IRQ 504 IRQ_TYPE_LEVEL_HIGH>;
 			#iommu-cells = <1>;
 			power-domains = <&ps_dispdfr_fe>;
+			status = "disabled";
+		};
+
+		displaydfr_mipi: dsi@228600000 {
+			compatible = "apple,t8103-display-pipe-mipi", "apple,h7-display-pipe-mipi";
+			reg = <0x2 0x28600000 0x0 0x100000>;
+			power-domains = <&ps_mipi_dsi>;
+			status = "disabled";
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				dfr_mipi_in: port@0 {
+					reg = <0>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					dfr_mipi_in_adp: endpoint@0 {
+						reg = <0>;
+						remote-endpoint = <&dfr_adp_out_mipi>;
+					};
+				};
+
+				dfr_mipi_out: port@1 {
+					reg = <1>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+				};
+			};
 		};
 
 		disp0_dart: iommu@231304000 {
@@ -623,10 +663,24 @@
 			resets = <&ps_disp0_cpu0>;
 			clocks = <&clk_disp0>;
 			phandle = <&dcp>;
+			// required bus properties for 'piodma' subdevice
+			#address-cells = <2>;
+			#size-cells = <2>;
 
 			disp0_piodma: piodma {
 				iommus = <&disp0_dart 4>;
 				phandle = <&disp0_piodma>;
+			};
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				port@0 {
+					reg = <0>;
+					dcp_audio: endpoint {
+						remote-endpoint = <&dpaudio0_dcp>;
+					};
+				};
 			};
 		};
 
@@ -784,10 +838,12 @@
 			interrupt-parent = <&aic>;
 			interrupts = <AIC_IRQ 614 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clk_200m>;
+			pinctrl-0 = <&spi0_pins>;
+			pinctrl-names = "default";
 			power-domains = <&ps_spi0>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			status = "disabled"; /* only used in J293 */
+			status = "disabled";
 		};
 
 		spi1: spi@235104000 {
@@ -815,7 +871,7 @@
 			power-domains = <&ps_spi3>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			status = "disabled"; /* only used in J293/J313 */
+			status = "disabled";
 		};
 
 		serial0: serial@235200000 {
@@ -846,6 +902,32 @@
 			status = "disabled";
 		};
 
+		sio_mbox: mbox@236408000 {
+			compatible = "apple,t8103-asc-mailbox", "apple,asc-mailbox-v4";
+			reg = <0x2 0x36408000 0x0 0x4000>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 640 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 641 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 642 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 643 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names = "send-empty", "send-not-empty",
+				"recv-empty", "recv-not-empty";
+			#mbox-cells = <0>;
+			power-domains = <&ps_sio>;
+		};
+
+		sio: sio@236400000 {
+			compatible = "apple,t8103-sio", "apple,sio";
+			reg = <0x2 0x36400000 0x0 0x8000>;
+			dma-channels = <128>;
+			#dma-cells = <1>;
+			mboxes = <&sio_mbox>;
+			iommus = <&sio_dart 0>;
+			power-domains = <&ps_sio_cpu>;
+			resets = <&ps_sio>; /* TODO: verify reset does something */
+			status = "disabled";
+		};
+
 		admac: dma-controller@238200000 {
 			compatible = "apple,t8103-admac", "apple,admac";
 			reg = <0x2 0x38200000 0x0 0x34000>;
@@ -858,6 +940,48 @@
 			iommus = <&sio_dart 2>;
 			power-domains = <&ps_sio_adma>;
 			resets = <&ps_audio_p>;
+		};
+
+		dpaudio0: audio-controller@238330000 {
+			compatible = "apple,t8103-dpaudio", "apple,dpaudio";
+			reg = <0x2 0x38330000 0x0 0x4000>;
+			dmas = <&sio 0x64>;
+			dma-names = "tx";
+			power-domains = <&ps_dpa0>;
+			reset-domains = <&ps_dpa0>;
+			status = "disabled";
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				port@0 {
+					reg = <0>;
+					dpaudio0_dcp: endpoint {
+						remote-endpoint = <&dcp_audio>;
+					};
+				};
+			};
+		};
+
+		dpaudio1: audio-controller@238334000 {
+			compatible = "apple,t8103-dpaudio", "apple,dpaudio";
+			reg = <0x2 0x38334000 0x0 0x4000>;
+			dmas = <&sio 0x66>;
+			dma-names = "tx";
+			power-domains = <&ps_dpa1>;
+			reset-domains = <&ps_dpa1>;
+			status = "disabled";
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				port@0 {
+					reg = <0>;
+					dpaudio1_dcp: endpoint {
+						remote-endpoint = <&dcpext_audio>;
+					};
+				};
+			};
 		};
 
 		mca: i2s@238400000 {
@@ -982,6 +1106,12 @@
 					 <APPLE_PINMUX(134, 1)>;
 			};
 
+			spi0_pins: spi0-pins {
+				pinmux = <APPLE_PINMUX(67, 1)>, /* CLK */
+					<APPLE_PINMUX(68, 1)>,  /* MOSI */
+					<APPLE_PINMUX(69, 1)>;  /* MISO */
+			};
+
 			spi1_pins: spi1-pins {
 				pinmux = <APPLE_PINMUX(42, 1)>,
 					<APPLE_PINMUX(43, 1)>,
@@ -1009,72 +1139,54 @@
 			#address-cells = <2>;
 			#size-cells = <0>;
 
-			pmu1: pmu@f {
-				compatible = "apple,sera-pmu", "apple,spmi-pmu";
+			pmic1: pmic@f {
+				compatible = "apple,sera-pmic", "apple,spmi-nvmem";
 				reg = <0xf SPMI_USID>;
-				#address-cells = <1>;
-				#size-cells = <1>;
 
-				rtc_nvmem@d000 {
-					compatible = "apple,spmi-pmu-nvmem";
-					reg = <0xd000 0x300>;
+				nvmem-layout {
+					compatible = "fixed-layout";
 					#address-cells = <1>;
 					#size-cells = <1>;
 
-					pm_setting: pm-setting@1 {
-						reg = <0x1 0x1>;
+					boot_stage: boot-stage@9f01 {
+						reg = <0x9f01 0x1>;
 					};
 
-					rtc_offset: rtc-offset@100 {
-						reg = <0x100 0x6>;
-					};
-				};
-
-				legacy_nvmem@9f00 {
-					compatible = "apple,spmi-pmu-nvmem";
-					reg = <0x9f00 0x20>;
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					boot_stage: boot-stage@1 {
-						reg = <0x1 0x1>;
-					};
-
-					boot_error_count: boot-error-count@2 {
-						reg = <0x2 0x1>;
+					boot_error_count: boot-error-count@9f02,0 {
+						reg = <0x9f02 0x1>;
 						bits = <0 4>;
 					};
 
-					panic_count: panic-count@2 {
-						reg = <0x2 0x1>;
+					panic_count: panic-count@9f02,4 {
+						reg = <0x9f02 0x1>;
 						bits = <4 4>;
 					};
 
-					boot_error_stage: boot-error-stage@3 {
-						reg = <0x3 0x1>;
+					boot_error_stage: boot-error-stage@9f03 {
+						reg = <0x9f03 0x1>;
 					};
 
-					shutdown_flag: shutdown-flag@f {
-						reg = <0xf 0x1>;
+					shutdown_flag: shutdown-flag@9f0f,3 {
+						reg = <0x9f0f 0x1>;
 						bits = <3 1>;
 					};
-				};
 
-				scrpad_nvmem@a000 {
-					compatible = "apple,spmi-pmu-nvmem";
-					reg = <0xa000 0x1000>;
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					fault_shadow: fault-shadow@67b {
-						reg = <0x67b 0x10>;
+					fault_shadow: fault-shadow@a67b {
+						reg = <0xa67b 0x10>;
 					};
 
-					socd: socd@b00 {
-						reg = <0xb00 0x400>;
+					socd: socd@ab00 {
+						reg = <0xab00 0x400>;
+					};
+
+					pm_setting: pm-setting@d001 {
+						reg = <0xd001 0x1>;
+					};
+
+					rtc_offset: rtc-offset@d100 {
+						reg = <0xd100 0x6>;
 					};
 				};
-
 			};
 		};
 
@@ -1115,6 +1227,38 @@
 			interrupts = <AIC_IRQ 338 IRQ_TYPE_LEVEL_HIGH>;
 		};
 
+		smc: smc@23e400000 {
+			compatible = "apple,t8103-smc", "apple,smc";
+			reg = <0x2 0x3e400000 0x0 0x4000>,
+				<0x2 0x3fe00000 0x0 0x100000>;
+			reg-names = "smc", "sram";
+			mboxes = <&smc_mbox>;
+
+			smc_gpio: gpio {
+				compatible = "apple,smc-gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
+
+			smc_hwmon: hwmon {
+				compatible = "apple,smc-hwmon";
+			};
+
+			smc_rtc: rtc {
+				compatible = "apple,smc-rtc";
+				nvmem-cells = <&rtc_offset>;
+				nvmem-cell-names = "rtc_offset";
+			};
+
+			smc_reboot: reboot {
+				compatible = "apple,smc-reboot";
+				nvmem-cells = <&shutdown_flag>, <&boot_stage>,
+					<&boot_error_count>, <&panic_count>, <&pm_setting>;
+				nvmem-cell-names = "shutdown_flag", "boot_stage",
+					"boot_error_count", "panic_count", "pm_setting";
+			};
+		};
+
 		smc_mbox: mbox@23e408000 {
 			compatible = "apple,t8103-asc-mailbox", "apple,asc-mailbox-v4";
 			reg = <0x2 0x3e408000 0x0 0x4000>;
@@ -1126,31 +1270,6 @@
 			interrupt-names = "send-empty", "send-not-empty",
 				"recv-empty", "recv-not-empty";
 			#mbox-cells = <0>;
-		};
-
-		smc: smc@23e400000 {
-			compatible = "apple,t8103-smc", "apple,smc";
-			reg = <0x2 0x3e400000 0x0 0x4000>,
-				<0x2 0x3fe00000 0x0 0x100000>;
-			reg-names = "smc", "sram";
-			mboxes = <&smc_mbox>;
-
-			smc_gpio: gpio {
-				gpio-controller;
-				#gpio-cells = <2>;
-			};
-
-			smc_rtc: rtc {
-				nvmem-cells = <&rtc_offset>;
-				nvmem-cell-names = "rtc_offset";
-			};
-
-			smc_reboot: reboot {
-				nvmem-cells = <&shutdown_flag>, <&boot_stage>,
-					<&boot_error_count>, <&panic_count>, <&pm_setting>;
-				nvmem-cell-names = "shutdown_flag", "boot_stage",
-					"boot_error_count", "panic_count", "pm_setting";
-			};
 		};
 
 		pinctrl_smc: pinctrl@23e820000 {
@@ -1174,6 +1293,36 @@
 				     <AIC_IRQ 397 IRQ_TYPE_LEVEL_HIGH>;
 		};
 
+		sep_dart: iommu@2412c0000 {
+			compatible = "apple,t8103-dart";
+			reg = <0x2 0x412c0000 0x0 0x4000>;
+			#iommu-cells = <1>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 259 IRQ_TYPE_LEVEL_HIGH>;
+		};
+
+		sep: sep@242400000 {
+			compatible = "apple,sep";
+			reg = <0x2 0x42400000 0x0 0x6C000>;
+			mboxes = <&sep_mbox>;
+			mbox-names = "mbox";
+			iommus = <&sep_dart 0>;
+			status = "disabled";
+		};
+
+		sep_mbox: mbox@242408000 {
+			compatible = "apple,t8103-asc-mailbox", "apple,asc-mailbox-v4";
+			reg = <0x2 0x42408000 0x0 0x4000>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 253 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 254 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 255 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 256 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names = "send-empty", "send-not-empty",
+				"recv-empty", "recv-not-empty";
+			#mbox-cells = <0>;
+		};
+
 		pinctrl_aop: pinctrl@24a820000 {
 			compatible = "apple,t8103-pinctrl", "apple,pinctrl";
 			reg = <0x2 0x4a820000 0x0 0x4000>;
@@ -1195,6 +1344,68 @@
 				     <AIC_IRQ 274 IRQ_TYPE_LEVEL_HIGH>;
 		};
 
+		aop_mbox: mbox@24a408000 {
+			compatible = "apple,t8103-asc-mailbox", "apple,asc-mailbox-v4";
+			reg = <0x2 0x4a408000 0x0 0x4000>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 285 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 286 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 287 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 288 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names = "send-empty", "send-not-empty",
+				"recv-empty", "recv-not-empty";
+			#mbox-cells = <0>;
+			status = "disabled";
+		};
+
+		aop_dart: iommu@24a808000 {
+			compatible = "apple,t8103-dart";
+			reg = <0x2 0x4a808000 0x0 0x4000>;
+			#iommu-cells = <1>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 300 IRQ_TYPE_LEVEL_HIGH>;
+			status = "disabled";
+		};
+
+		aop_admac: dma-controller@24a980000 {
+			compatible = "apple,t8103-admac", "apple,admac";
+			reg = <0x2 0x4a980000 0x0 0x34000>;
+			#dma-cells = <1>;
+			dma-channels = <16>;
+			interrupts-extended = <0>,
+					      <0>,
+					      <&aic AIC_IRQ 321 IRQ_TYPE_LEVEL_HIGH>,
+					      <0>;
+			iommus = <&aop_dart 7>;
+			status = "disabled";
+		};
+
+		aop: aop@24ac00000 {
+			compatible = "apple,t8103-aop";
+			reg = <0x2 0x4ac00000 0x0 0x1e0000>,
+			      <0x2 0x4a400000 0x0 0x6c000>;
+			mboxes = <&aop_mbox>;
+			mbox-names = "mbox";
+			iommus = <&aop_dart 0>;
+
+			status = "disabled";
+
+			aop_audio: audio {
+				compatible = "apple,t8103-aop-audio", "apple,aop-audio";
+				dmas = <&aop_admac 1>;
+				dma-names = "dma";
+			};
+
+			aop_als: als {
+				compatible = "apple,t8103-aop-als", "apple,aop-als";
+				// intentionally empty
+			};
+
+			las {
+				compatible = "apple,t8103-aop-las", "apple,aop-las";
+			};
+		};
+
 		dispext0_dart: iommu@271304000 {
 			compatible = "apple,t8103-dart";
 			reg = <0x2 0x71304000 0x0 0x4000>;
@@ -1202,6 +1413,7 @@
 			interrupt-parent = <&aic>;
 			interrupts = <AIC_IRQ 481 IRQ_TYPE_LEVEL_HIGH>;
 			power-domains = <&ps_dispext_cpu0>;
+			apple,dma-range = <0x0 0x0 0x0 0xfc000000>;
 			status = "disabled";
 		};
 
@@ -1212,6 +1424,7 @@
 			interrupt-parent = <&aic>;
 			interrupts = <AIC_IRQ 481 IRQ_TYPE_LEVEL_HIGH>;
 			power-domains = <&ps_dispext_cpu0>;
+			apple,dma-range = <0xf 0x00000000 0x0 0xfc000000>;
 			status = "disabled";
 		};
 
@@ -1251,12 +1464,24 @@
 			power-domains = <&ps_dispext_cpu0>;
 			resets = <&ps_dispext_cpu0>;
 			clocks = <&clk_dispext0>;
-			apple,asc-dram-mask = <0xf 0x00000000>;
 			status = "disabled";
+			// required bus properties for 'piodma' subdevice
+			#address-cells = <2>;
+			#size-cells = <2>;
 
-			dispext0_piodma: piodma {
+			piodma {
 				iommus = <&dispext0_dart 4>;
-				phandle = <&dispext0_piodma>;
+			};
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				port@0 {
+					reg = <0>;
+					dcpext_audio: endpoint {
+						remote-endpoint = <&dpaudio1_dcp>;
+					};
+				};
 			};
 		};
 
@@ -1396,8 +1621,9 @@
 		};
 
 		dwc3_0: usb@382280000 {
-			compatible = "apple,t8103-dwc3", "apple,dwc3", "snps,dwc3";
-			reg = <0x3 0x82280000 0x0 0x100000>;
+			compatible = "apple,t8103-dwc3";
+			reg = <0x3 0x82280000 0x0 0xcd00>, <0x3 0x8228cd00 0x0 0x3200>;
+			reg-names = "dwc3-core", "dwc3-apple";
 			interrupt-parent = <&aic>;
 			interrupts = <AIC_IRQ 777 IRQ_TYPE_LEVEL_HIGH>;
 			dr_mode = "otg";
@@ -1462,13 +1688,20 @@
 
 			orientation-switch;
 			mode-switch;
-			svid = <0xff01>, <0x8087>;
+			power-domains = <&ps_atc0_usb>;
+		};
+
+		atcphy0_xbar: mux@38304c000 {
+			compatible = "apple,t8103-display-crossbar";
+			reg = <0x3 0x8304c000 0x0 0x4000>;
+			#mux-control-cells = <1>;
 			power-domains = <&ps_atc0_usb>;
 		};
 
 		dwc3_1: usb@502280000 {
-			compatible = "apple,t8103-dwc3", "apple,dwc3", "snps,dwc3";
-			reg = <0x5 0x02280000 0x0 0x100000>;
+			compatible = "apple,t8103-dwc3";
+			reg = <0x5 0x02280000 0x0 0xcd00>, <0x5 0x0228cd00 0x0 0x3200>;
+			reg-names = "dwc3-core", "dwc3-apple";
 			interrupt-parent = <&aic>;
 			interrupts = <AIC_IRQ 857 IRQ_TYPE_LEVEL_HIGH>;
 			dr_mode = "otg";
@@ -1535,7 +1768,13 @@
 
 			orientation-switch;
 			mode-switch;
-			svid = <0xff01>, <0x8087>;
+			power-domains = <&ps_atc1_usb>;
+		};
+
+		atcphy1_xbar: mux@50304c000 {
+			compatible = "apple,t8103-display-crossbar";
+			reg = <0x5 0x0304c000 0x0 0x4000>;
+			#mux-control-cells = <1>;
 			power-domains = <&ps_atc1_usb>;
 		};
 
@@ -1603,6 +1842,8 @@
 			power-domains = <&ps_apcie_gp>;
 			pinctrl-0 = <&pcie_pins>;
 			pinctrl-names = "default";
+
+			dma-coherent;
 
 			port00: pci@0,0 {
 				device_type = "pci";

--- a/arch/arm/dts/t8112-j413.dts
+++ b/arch/arm/dts/t8112-j413.dts
@@ -16,11 +16,12 @@
 / {
 	compatible = "apple,j413", "apple,t8112", "apple,arm-platform";
 	model = "Apple MacBook Air (13-inch, M2, 2022)";
+	chassis-type = "laptop";
 
 	aliases {
 		bluetooth0 = &bluetooth0;
-		wifi0 = &wifi0;
 		keyboard = &keyboard;
+		wifi0 = &wifi0;
 	};
 
 	led-controller {
@@ -44,6 +45,11 @@
 		adj-height-mm = <181>;
 		apple,max-brightness = <525>;
 	};
+};
+
+&framebuffer0 {
+	panel = <&panel>;
+	post-init-providers = <&panel>;
 };
 
 /*
@@ -173,6 +179,27 @@
 	status = "okay";
 };
 
+&aop_mbox {
+       status = "okay";
+};
+
+&aop_dart {
+       status = "okay";
+};
+
+&aop_admac {
+       status = "okay";
+};
+
+&aop {
+	status = "okay";
+};
+
+&aop_audio {
+	apple,chassis-name = "J413";
+	apple,machine-kind = "MacBook Air";
+};
+
 / {
 	sound {
 		compatible = "apple,j413-macaudio", "apple,macaudio";
@@ -244,3 +271,5 @@
 	apple,platform-id = <14>;
 	apple,temporal-filter = <1>;
 };
+
+#include "hwmon-laptop.dtsi"

--- a/arch/arm/dts/t8112-j415.dts
+++ b/arch/arm/dts/t8112-j415.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0+ OR MIT
 /*
- * Apple MacBook Air (15-inchl, M2, 2023)
+ * Apple MacBook Air (15-inch, M2, 2023)
  *
  * target-type: J415
  *
@@ -16,11 +16,12 @@
 / {
 	compatible = "apple,j415", "apple,t8112", "apple,arm-platform";
 	model = "Apple MacBook Air (15-inch, M2, 2023)";
+	chassis-type = "laptop";
 
 	aliases {
 		bluetooth0 = &bluetooth0;
-		wifi0 = &wifi0;
 		keyboard = &keyboard;
+		wifi0 = &wifi0;
 	};
 
 	led-controller {
@@ -44,6 +45,11 @@
 		adj-height-mm = <204>;
 		apple,max-brightness = <500>;
 	};
+};
+
+&framebuffer0 {
+	panel = <&panel>;
+	post-init-providers = <&panel>;
 };
 
 /*
@@ -187,8 +193,33 @@
 	};
 };
 
+&i2c4 {
+	status = "okay";
+};
+
 &fpwm1 {
 	status = "okay";
+};
+
+&aop_mbox {
+       status = "okay";
+};
+
+&aop_dart {
+       status = "okay";
+};
+
+&aop_admac {
+       status = "okay";
+};
+
+&aop {
+	status = "okay";
+};
+
+&aop_audio {
+	apple,chassis-name = "J415";
+	apple,machine-kind = "MacBook Air";
 };
 
 / {
@@ -266,3 +297,5 @@
 	apple,platform-id = <15>;
 	apple,temporal-filter = <1>;
 };
+
+#include "hwmon-laptop.dtsi"

--- a/arch/arm/dts/t8112-j473.dts
+++ b/arch/arm/dts/t8112-j473.dts
@@ -15,12 +15,14 @@
 / {
 	compatible = "apple,j473", "apple,t8112", "apple,arm-platform";
 	model = "Apple Mac mini (M2, 2023)";
+	chassis-type = "desktop";
 
 	aliases {
 		bluetooth0 = &bluetooth0;
 		/delete-property/ dcp;
 		dcpext = &dcpext;
 		ethernet0 = &ethernet0;
+		sio = &sio;
 		wifi0 = &wifi0;
 	};
 };
@@ -64,16 +66,32 @@
 	apple,dptx-phy = <5>;
 };
 
-/*
- * Provide labels for the USB type C ports.
- */
-
-&typec0 {
-	label = "USB-C Back-left";
+/* remove once m1n1 enables sio nodes after setup */
+&sio {
+        status = "okay";
 };
 
-&typec1 {
-	label = "USB-C Back-right";
+&dpaudio1 {
+	status = "okay";
+};
+
+/*
+ * Keep the power-domains used for the HDMI port on.
+ */
+&framebuffer0 {
+	power-domains = <&ps_dispext_cpu0>, <&ps_dptx_ext_phy>;
+};
+
+/*
+ * The M2 Mac mini uses dispext for the HDMI output so it's not necessary to
+ * keep disp0 power-domains always-on.
+ */
+&ps_disp0_sys {
+	/delete-property/ apple,always-on;
+};
+
+&ps_disp0_fe {
+	/delete-property/ apple,always-on;
 };
 
 /*
@@ -124,6 +142,18 @@
 
 &pcie2_dart {
 	status = "okay";
+};
+
+/*
+ * Provide labels for the USB type C ports.
+ */
+
+&typec0 {
+	label = "USB-C Back-left";
+};
+
+&typec1 {
+	label = "USB-C Back-right";
 };
 
 &i2c1 {
@@ -183,3 +213,5 @@
 &gpu {
 	apple,perf-base-pstate = <3>;
 };
+
+#include "hwmon-mini.dtsi"

--- a/arch/arm/dts/t8112-j493.dts
+++ b/arch/arm/dts/t8112-j493.dts
@@ -16,12 +16,17 @@
 / {
 	compatible = "apple,j493", "apple,t8112", "apple,arm-platform";
 	model = "Apple MacBook Pro (13-inch, M2, 2022)";
+	chassis-type = "laptop";
 
+	/*
+	 * All of those are used by the bootloader to pass calibration
+	 * blobs and other device-specific properties
+	 */
 	aliases {
 		bluetooth0 = &bluetooth0;
-		wifi0 = &wifi0;
 		keyboard = &keyboard;
 		touchbar0 = &touchbar0;
+		wifi0 = &wifi0;
 	};
 
 	led-controller {
@@ -37,6 +42,16 @@
 	};
 };
 
+/*
+ * The driver depends on boot loader initialized state which resets when this
+ * power-domain is powered off. This happens on suspend or when the driver is
+ * missing during boot. Mark the domain as always on until the driver can
+ * handle this.
+ */
+&ps_dispdfr_be {
+	apple,always-on;
+};
+
 &dcp {
 	panel: panel {
 		compatible = "apple,panel-j493", "apple,panel";
@@ -46,14 +61,37 @@
 	};
 };
 
+&framebuffer0 {
+	panel = <&panel>;
+	post-init-providers = <&panel>;
+};
+
 &display_dfr {
+	status = "okay";
+};
+
+&dfr_mipi_out {
+	dfr_mipi_out_panel: endpoint@0 {
+		reg = <0>;
+		remote-endpoint = <&dfr_panel_in>;
+	};
+};
+
+&displaydfr_mipi {
 	status = "okay";
 	#address-cells = <1>;
 	#size-cells = <0>;
 
 	dfr_panel: panel@0 {
-		compatible = "apple,summit";
+		compatible = "apple,j493-summit", "apple,summit";
 		reg = <0>;
+		max-brightness = <255>;
+
+		port {
+			dfr_panel_in: endpoint {
+				remote-endpoint = <&dfr_mipi_out_panel>;
+			};
+		};
 	};
 };
 
@@ -177,6 +215,45 @@
 	status = "okay";
 };
 
+&spi3 {
+	status = "okay";
+
+	touchbar0: touchbar@0 {
+		compatible = "apple,j493-touchbar";
+		reg = <0>;
+		spi-max-frequency = <8000000>;
+		spi-cs-setup-delay-ns = <2000>;
+		spi-cs-hold-delay-ns = <2000>;
+		reset-gpios = <&pinctrl_ap 170 GPIO_ACTIVE_LOW>;
+		interrupts-extended = <&pinctrl_ap 174 IRQ_TYPE_EDGE_FALLING>;
+		firmware-name = "apple/dfrmtfw-j493.bin";
+		touchscreen-size-x = <23045>;
+		touchscreen-size-y = <640>;
+		touchscreen-inverted-y;
+	};
+};
+
+&aop_mbox {
+       status = "okay";
+};
+
+&aop_dart {
+       status = "okay";
+};
+
+&aop_admac {
+       status = "okay";
+};
+
+&aop {
+	status = "okay";
+};
+
+&aop_audio {
+	apple,chassis-name = "J493";
+	apple,machine-kind = "MacBook Pro";
+};
+
 / {
 	sound {
 		compatible = "apple,j493-macaudio", "apple,macaudio";
@@ -205,25 +282,6 @@
 			};
 		};
 	};
-};
-
-&spi3 {
-	status = "okay";
-
-	touchbar0: touchbar@0 {
-		compatible = "apple,j493-touchbar", "apple,z2-touchbar", "apple,z2-multitouch";
-		reg = <0>;
-		label = "Mac14,7 Touch Bar";
-		spi-max-frequency = <8000000>;
-		spi-cs-setup-delay-ns = <2000>;
-		spi-cs-hold-delay-ns = <2000>;
-
-		reset-gpios = <&pinctrl_ap 170 GPIO_ACTIVE_LOW>;
-		interrupts-extended = <&pinctrl_ap 174 IRQ_TYPE_EDGE_FALLING>;
-		firmware-name = "apple/dfrmtfw-j493.bin";
-		touchscreen-size-x = <23045>;
-		touchscreen-size-y = <640>;
-       };
 };
 
 &mtp {
@@ -266,3 +324,6 @@
 &isp {
 	apple,platform-id = <6>;
 };
+
+#include "hwmon-fan.dtsi"
+#include "hwmon-laptop.dtsi"

--- a/arch/arm/dts/t8112-jxxx.dtsi
+++ b/arch/arm/dts/t8112-jxxx.dtsi
@@ -16,7 +16,6 @@
 		dcp = &dcp;
 		disp0 = &display;
 		disp0_piodma = &disp0_piodma;
-		nvram = &nvram;
 		serial0 = &serial0;
 		serial2 = &serial2;
 	};
@@ -35,13 +34,6 @@
 			/* Format properties will be added by loader */
 			status = "disabled";
 		};
-	};
-
-	reserved-memory {
-		#address-cells = <2>;
-		#size-cells = <2>;
-		ranges;
-		/* To be filled by loader */
 	};
 
 	memory@800000000 {
@@ -78,14 +70,14 @@
 				#size-cells = <0>;
 				port@0 {
 					reg = <0>;
-					typec0_con_hs: endpoint {
-						remote-endpoint = <&typec0_usb_hs>;
+					typec0_connector_hs: endpoint {
+						remote-endpoint = <&dwc3_0_hs>;
 					};
 				};
 				port@1 {
 					reg = <1>;
-					typec0_con_ss: endpoint {
-						remote-endpoint = <&typec0_usb_ss>;
+					typec0_connector_ss: endpoint {
+						remote-endpoint = <&atcphy0_typec_lanes>;
 					};
 				};
 			};
@@ -109,14 +101,14 @@
 				#size-cells = <0>;
 				port@0 {
 					reg = <0>;
-					typec1_con_hs: endpoint {
-						remote-endpoint = <&typec1_usb_hs>;
+					typec1_connector_hs: endpoint {
+						remote-endpoint = <&dwc3_1_hs>;
 					};
 				};
 				port@1 {
 					reg = <1>;
-					typec1_con_ss: endpoint {
-						remote-endpoint = <&typec1_usb_ss>;
+					typec1_connector_ss: endpoint {
+						remote-endpoint = <&atcphy1_typec_lanes>;
 					};
 				};
 			};
@@ -126,34 +118,86 @@
 
 /* USB controllers */
 &dwc3_0 {
-	port {
-		typec0_usb_hs: endpoint {
-			remote-endpoint = <&typec0_con_hs>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			dwc3_0_hs: endpoint {
+				remote-endpoint = <&typec0_connector_hs>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			dwc3_0_ss: endpoint {
+				remote-endpoint = <&atcphy0_usb3>;
+			};
 		};
 	};
 };
 
 &dwc3_1 {
-	port {
-		typec1_usb_hs: endpoint {
-			remote-endpoint = <&typec1_con_hs>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			dwc3_1_hs: endpoint {
+				remote-endpoint = <&typec1_connector_hs>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			dwc3_1_ss: endpoint {
+				remote-endpoint = <&atcphy1_usb3>;
+			};
 		};
 	};
 };
 
 /* Type-C PHYs */
 &atcphy0 {
-	port {
-		typec0_usb_ss: endpoint {
-			remote-endpoint = <&typec0_con_ss>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			atcphy0_typec_lanes: endpoint {
+				remote-endpoint = <&typec0_connector_ss>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			atcphy0_usb3: endpoint {
+				remote-endpoint = <&dwc3_0_ss>;
+			};
 		};
 	};
 };
 
 &atcphy1 {
-	port {
-		typec1_usb_ss: endpoint {
-			remote-endpoint = <&typec1_con_ss>;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			atcphy1_typec_lanes: endpoint {
+				remote-endpoint = <&typec1_connector_ss>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			atcphy1_usb3: endpoint {
+				remote-endpoint = <&dwc3_1_ss>;
+			};
 		};
 	};
 };
@@ -173,5 +217,7 @@
 &nco_clkref {
 	clock-frequency = <900000000>;
 };
+
+#include "hwmon-common.dtsi"
 
 #include "spi1-nvram.dtsi"

--- a/arch/arm/dts/t8112-pmgr.dtsi
+++ b/arch/arm/dts/t8112-pmgr.dtsi
@@ -176,7 +176,7 @@
 		#power-domain-cells = <0>;
 		#reset-cells = <0>;
 		label = "sio_cpu";
-		power-domains = <&ps_sio>;
+		power-domains = <&ps_sio &ps_uart_p &ps_spi_p &ps_dpa0>;
 	};
 
 	ps_fpwm0: power-controller@1c8 {

--- a/arch/arm/dts/t8112.dtsi
+++ b/arch/arm/dts/t8112.dtsi
@@ -429,6 +429,13 @@
 		clock-output-names = "clkref";
 	};
 
+	clk_200m: clock-200m {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <200000000>;
+		clock-output-names = "clk_200m";
+	};
+
 	/*
 	 * This is a fabulated representation of the input clock
 	 * to NCO since we don't know the true clock tree.
@@ -460,27 +467,29 @@
 		#size-cells = <2>;
 		ranges;
 
+		gpu_globals: globals {
+			status = "disabled";
+		};
+
+		gpu_hw_cal_a: hw-cal-a {
+			status = "disabled";
+		};
+
+		gpu_hw_cal_b: hw-cal-b {
+			status = "disabled";
+		};
+
 		uat_handoff: uat-handoff {
-			reg = <0x0 0 0 0>;
-			no-map;
+			reg = <0 0 0 0>;
 		};
 
 		uat_pagetables: uat-pagetables {
-			reg = <0x0 0 0 0>;
-			no-map;
+			reg = <0 0 0 0>;
 		};
 
 		uat_ttbs: uat-ttbs {
-			reg = <0x0 0 0 0>;
-			no-map;
+			reg = <0 0 0 0>;
 		};
-	};
-
-	clk_200m: clock-200m {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-frequency = <200000000>;
-		clock-output-names = "clk_200m";
 	};
 
 	soc {
@@ -498,17 +507,14 @@
 			reg = <0x2 0x6400000 0 0x40000>,
 				<0x2 0x4000000 0 0x1000000>;
 			reg-names = "asc", "sgx";
-			interrupt-parent = <&aic>;
-			interrupts = <AIC_IRQ 697 IRQ_TYPE_LEVEL_HIGH>,
-				<AIC_IRQ 698 IRQ_TYPE_LEVEL_HIGH>,
-				<AIC_IRQ 699 IRQ_TYPE_LEVEL_HIGH>,
-				<AIC_IRQ 700 IRQ_TYPE_LEVEL_HIGH>,
-				<AIC_IRQ 713 IRQ_TYPE_LEVEL_HIGH>;
 			mboxes = <&agx_mbox>;
 			power-domains = <&ps_gfx>;
-			memory-region = <&uat_ttbs>, <&uat_pagetables>, <&uat_handoff>;
-			memory-region-names = "ttbs", "pagetables", "handoff";
+			memory-region = <&uat_ttbs>, <&uat_pagetables>, <&uat_handoff>,
+					<&gpu_hw_cal_a>, <&gpu_hw_cal_b>, <&gpu_globals>;
+			memory-region-names = "ttbs", "pagetables", "handoff",
+					      "hw-cal-a", "hw-cal-b", "globals";
 
+			apple,firmware-abi = <0 0 0>;
 			apple,firmware-version = <12 4 0>;
 			apple,firmware-compat = <12 4 0>;
 
@@ -569,17 +575,22 @@
 
 		display_dfr: display-pipe@228200000 {
 			compatible = "apple,t8112-display-pipe", "apple,h7-display-pipe";
-			reg-names = "be", "fe", "mipi";
 			reg = <0x2 0x28200000 0x0 0xc000>,
-				<0x2 0x28400000 0x0 0x4000>,
-				<0x2 0x28600000 0x0 0x100000>;
-			power-domains = <&ps_dispdfr_fe>, <&ps_dispdfr_be>, <&ps_mipi_dsi>;
+			      <0x2 0x28400000 0x0 0x4000>;
+			reg-names = "be", "fe";
+			power-domains = <&ps_dispdfr_fe>, <&ps_dispdfr_be>;
 			interrupt-parent = <&aic>;
 			interrupts = <AIC_IRQ 614 IRQ_TYPE_LEVEL_HIGH>,
-				<AIC_IRQ 618 IRQ_TYPE_LEVEL_HIGH>;
+				     <AIC_IRQ 618 IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-names = "be", "fe";
-			status = "disabled";
 			iommus = <&displaydfr_dart 0>;
+			status = "disabled";
+
+			port {
+				dfr_adp_out_mipi: endpoint {
+					remote-endpoint = <&dfr_mipi_in_adp>;
+				};
+			};
 		};
 
 		displaydfr_dart: iommu@228304000 {
@@ -590,6 +601,35 @@
 			#iommu-cells = <1>;
 			power-domains = <&ps_dispdfr_fe>;
 			status = "disabled";
+		};
+
+		displaydfr_mipi: dsi@228600000 {
+			compatible = "apple,t8112-display-pipe-mipi", "apple,h7-display-pipe-mipi";
+			reg = <0x2 0x28600000 0x0 0x100000>;
+			power-domains = <&ps_mipi_dsi>;
+			status = "disabled";
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				dfr_mipi_in: port@0 {
+					reg = <0>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					dfr_mipi_in_adp: endpoint@0 {
+						reg = <0>;
+						remote-endpoint = <&dfr_adp_out_mipi>;
+					};
+				};
+
+				dfr_mipi_out: port@1 {
+					reg = <1>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+				};
+			};
 		};
 
 		isp_dart0: iommu@22c4a8000 {
@@ -697,10 +737,24 @@
 			resets = <&ps_disp0_cpu0>;
 			clocks = <&clk_disp0>;
 			phandle = <&dcp>;
+			// required bus properties for 'piodma' subdevice
+			#address-cells = <2>;
+			#size-cells = <2>;
 
 			disp0_piodma: piodma {
 				iommus = <&disp0_dart 4>;
 				phandle = <&disp0_piodma>;
+			};
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				port@0 {
+					reg = <0>;
+					dcp_audio: endpoint {
+						remote-endpoint = <&dpaudio0_dcp>;
+					};
+				};
 			};
 		};
 
@@ -825,7 +879,7 @@
 			power-domains = <&ps_spi3>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			status = "disabled";
+			status = "disabled"; /* only used in J493 */
 		};
 
 		serial0: serial@235200000 {
@@ -856,6 +910,32 @@
 			status = "disabled";
 		};
 
+		sio_mbox: mbox@236408000 {
+			compatible = "apple,t8112-asc-mailbox", "apple,asc-mailbox-v4";
+			reg = <0x2 0x36408000 0x0 0x4000>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 774 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 775 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 776 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 777 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names = "send-empty", "send-not-empty",
+				"recv-empty", "recv-not-empty";
+			#mbox-cells = <0>;
+			power-domains = <&ps_sio_cpu>;
+		};
+
+		sio: sio@236400000 {
+			compatible = "apple,t8112-sio", "apple,sio";
+			reg = <0x2 0x36400000 0x0 0x8000>;
+			dma-channels = <128>;
+			#dma-cells = <1>;
+			mboxes = <&sio_mbox>;
+			iommus = <&sio_dart 0>;
+			power-domains = <&ps_sio_cpu>;
+			resets = <&ps_sio>; /* TODO: verify reset does something */
+			status = "disabled";
+		};
+
 		admac: dma-controller@238200000 {
 			compatible = "apple,t8112-admac", "apple,admac";
 			reg = <0x2 0x38200000 0x0 0x34000>;
@@ -868,6 +948,48 @@
 			iommus = <&sio_dart 2>;
 			power-domains = <&ps_sio_adma>;
 			resets = <&ps_audio_p>;
+		};
+
+		dpaudio0: audio-controller@238330000 {
+			compatible = "apple,t8112-dpaudio", "apple,dpaudio";
+			reg = <0x2 0x38330000 0x0 0x4000>;
+			dmas = <&sio 0x64>;
+			dma-names = "tx";
+			power-domains = <&ps_dpa0>;
+			reset-domains = <&ps_dpa0>;
+			status = "disabled";
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				port@0 {
+					reg = <0>;
+					dpaudio0_dcp: endpoint {
+						remote-endpoint = <&dcp_audio>;
+					};
+				};
+			};
+		};
+
+		dpaudio1: audio-controller@238334000 {
+			compatible = "apple,t8112-dpaudio", "apple,dpaudio";
+			reg = <0x2 0x38334000 0x0 0x4000>;
+			dmas = <&sio 0x66>;
+			dma-names = "tx";
+			power-domains = <&ps_dpa1>;
+			reset-domains = <&ps_dpa1>;
+			status = "disabled";
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				port@0 {
+					reg = <0>;
+					dpaudio1_dcp: endpoint {
+						remote-endpoint = <&dcpext_audio>;
+					};
+				};
+			};
 		};
 
 		mca: i2s@238400000 {
@@ -1020,88 +1142,10 @@
 			reg = <0x2 0x3c500000 0x0 0x4000>,
 				<0x2 0x3c540000 0x0 0xc000>;
 			reg-names = "core", "dptx";
-			power-domain = <&ps_dptx_ext_phy>;
+			power-domains = <&ps_dptx_ext_phy>;
 			#phy-cells = <0>;
 			#reset-cells = <0>;
 			status = "disabled"; /* only used on j473 */
-               };
-
-		nub_spmi: spmi@23d0d9300 {
-			compatible = "apple,t8112-spmi", "apple,spmi";
-			reg = <0x2 0x3d714000 0x0 0x100>;
-			#address-cells = <2>;
-			#size-cells = <0>;
-			interrupt-parent = <&aic>;
-			interrupts = <AIC_IRQ 256 IRQ_TYPE_LEVEL_HIGH>,
-				<AIC_IRQ 384 IRQ_TYPE_LEVEL_HIGH>;
-
-			pmu1: pmu@e {
-				compatible = "apple,stowe-pmu", "apple,spmi-pmu";
-				reg = <0xe SPMI_USID>;
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				rtc_nvmem@f800 {
-					compatible = "apple,spmi-pmu-nvmem";
-					reg = <0xf800 0x300>;
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					pm_setting: pm-setting@1 {
-						reg = <0x1 0x1>;
-					};
-
-					rtc_offset: rtc-offset@100 {
-						reg = <0x100 0x6>;
-					};
-				};
-
-				legacy_nvmem@f700 {
-					compatible = "apple,spmi-pmu-nvmem";
-					reg = <0xf700 0x20>;
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					boot_stage: boot-stage@1 {
-						reg = <0x1 0x1>;
-					};
-
-					boot_error_count: boot-error-count@2 {
-						reg = <0x2 0x1>;
-						bits = <0 4>;
-					};
-
-					panic_count: panic-count@2 {
-						reg = <0x2 0x1>;
-						bits = <4 4>;
-					};
-
-					boot_error_stage: boot-error-stage@3 {
-						reg = <0x3 0x1>;
-					};
-
-					shutdown_flag: shutdown-flag@f {
-						reg = <0xf 0x1>;
-						bits = <3 1>;
-					};
-				};
-
-				scrpad_nvmem@8000 {
-					compatible = "apple,spmi-pmu-nvmem";
-					reg = <0x8000 0x2800>;
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					fault_shadow: fault-shadow@67b {
-						reg = <0x67b 0x10>;
-					};
-
-					socd: socd@b00 {
-						reg = <0xb00 0x400>;
-					};
-				};
-
-			};
 		};
 
 		pinctrl_nub: pinctrl@23d1f0000 {
@@ -1239,6 +1283,95 @@
 			};
 		};
 
+		nub_spmi: spmi@23d714000 {
+			compatible = "apple,t8112-spmi", "apple,spmi";
+			reg = <0x2 0x3d714000 0x0 0x100>;
+			#address-cells = <2>;
+			#size-cells = <0>;
+
+			pmic1: pmic@e {
+				compatible = "apple,stowe-pmic", "apple,spmi-nvmem";
+				reg = <0xe SPMI_USID>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					fault_shadow: fault-shadow@867b {
+						reg = <0x867b 0x10>;
+					};
+
+					socd: socd@8b00 {
+						reg = <0x8b00 0x400>;
+					};
+
+					boot_stage: boot-stage@f701 {
+						reg = <0xf701 0x1>;
+					};
+
+					boot_error_count: boot-error-count@f702,0 {
+						reg = <0xf702 0x1>;
+						bits = <0 4>;
+					};
+
+					panic_count: panic-count@f702,4 {
+						reg = <0xf702 0x1>;
+						bits = <4 4>;
+					};
+
+					boot_error_stage: boot-error-stage@f703 {
+						reg = <0xf703 0x1>;
+					};
+
+					shutdown_flag: shutdown-flag@f70f,3 {
+						reg = <0xf70f 0x1>;
+						bits = <3 1>;
+					};
+
+					pm_setting: pm-setting@f801 {
+						reg = <0xf801 0x1>;
+					};
+
+					rtc_offset: rtc-offset@f900 {
+						reg = <0xf900 0x6>;
+					};
+				};
+			};
+		};
+
+		smc: smc@23e400000 {
+			compatible = "apple,t8112-smc", "apple,smc";
+			reg = <0x2 0x3e400000 0x0 0x4000>,
+				<0x2 0x3fe00000 0x0 0x100000>;
+			reg-names = "smc", "sram";
+			mboxes = <&smc_mbox>;
+
+			smc_gpio: gpio {
+				compatible = "apple,smc-gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+			};
+
+			smc_hwmon: hwmon {
+				compatible = "apple,smc-hwmon";
+			};
+
+			smc_rtc: rtc {
+				compatible = "apple,smc-rtc";
+				nvmem-cells = <&rtc_offset>;
+				nvmem-cell-names = "rtc_offset";
+			};
+
+			smc_reboot: reboot {
+				compatible = "apple,smc-reboot";
+				nvmem-cells = <&shutdown_flag>, <&boot_stage>,
+					<&boot_error_count>, <&panic_count>, <&pm_setting>;
+				nvmem-cell-names = "shutdown_flag", "boot_stage",
+					"boot_error_count", "panic_count", "pm_setting";
+			};
+		};
+
 		smc_mbox: mbox@23e408000 {
 			compatible = "apple,t8112-asc-mailbox", "apple,asc-mailbox-v4";
 			reg = <0x2 0x3e408000 0x0 0x4000>;
@@ -1250,31 +1383,6 @@
 			interrupt-names = "send-empty", "send-not-empty",
 				"recv-empty", "recv-not-empty";
 			#mbox-cells = <0>;
-		};
-
-		smc: smc@23e400000 {
-			compatible = "apple,t8112-smc", "apple,smc";
-			reg = <0x2 0x3e400000 0x0 0x4000>,
-				<0x2 0x3fe00000 0x0 0x100000>;
-			reg-names = "smc", "sram";
-			mboxes = <&smc_mbox>;
-
-			smc_gpio: gpio {
-				gpio-controller;
-				#gpio-cells = <2>;
-			};
-
-			smc_rtc: rtc {
-				nvmem-cells = <&rtc_offset>;
-				nvmem-cell-names = "rtc_offset";
-			};
-
-			smc_reboot: reboot {
-				nvmem-cells = <&shutdown_flag>, <&boot_stage>,
-					<&boot_error_count>, <&panic_count>, <&pm_setting>;
-				nvmem-cell-names = "shutdown_flag", "boot_stage",
-					"boot_error_count", "panic_count", "pm_setting";
-			};
 		};
 
 		pinctrl_smc: pinctrl@23e820000 {
@@ -1317,6 +1425,68 @@
 				     <AIC_IRQ 305 IRQ_TYPE_LEVEL_HIGH>,
 				     <AIC_IRQ 306 IRQ_TYPE_LEVEL_HIGH>,
 				     <AIC_IRQ 307 IRQ_TYPE_LEVEL_HIGH>;
+		};
+
+		aop_mbox: mbox@24a408000 {
+			compatible = "apple,t8112-asc-mailbox", "apple,asc-mailbox-v4";
+			reg = <0x2 0x4a408000 0x0 0x4000>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 318 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 319 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 320 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 321 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names = "send-empty", "send-not-empty",
+				"recv-empty", "recv-not-empty";
+			#mbox-cells = <0>;
+			status = "disabled";
+		};
+
+		aop_dart: iommu@24a808000 {
+			compatible = "apple,t8112-dart", "apple,t8110-dart";
+			reg = <0x2 0x4a808000 0x0 0x4000>;
+			#iommu-cells = <1>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 338 IRQ_TYPE_LEVEL_HIGH>;
+			status = "disabled";
+		};
+
+		aop_admac: dma-controller@24a980000 {
+			compatible = "apple,t8112-admac", "apple,admac";
+			reg = <0x2 0x4a980000 0x0 0x34000>;
+			#dma-cells = <1>;
+			dma-channels = <16>;
+			interrupts-extended = <0>,
+					      <0>,
+					      <&aic AIC_IRQ 359 IRQ_TYPE_LEVEL_HIGH>,
+					      <0>;
+			iommus = <&aop_dart 10>;
+			status = "disabled";
+		};
+
+		aop: aop@24ac00000 {
+			compatible = "apple,t8112-aop";
+			reg = <0x2 0x4ac00000 0x0 0x1e0000>,
+			      <0x2 0x4a400000 0x0 0x6c000>;
+			mboxes = <&aop_mbox>;
+			mbox-names = "mbox";
+			iommus = <&aop_dart 0>;
+
+			status = "disabled";
+
+			aop_audio: audio {
+				compatible = "apple,t8112-aop-audio", "apple,aop-audio";
+				dmas = <&aop_admac 1>;
+				dma-names = "dma";
+			};
+
+			aop_als: als {
+				compatible = "apple,t8112-aop-als", "apple,aop-als";
+				// intentionally empty
+			};
+
+			las {
+				compatible = "apple,t8112-aop-las", "apple,aop-las";
+			};
 		};
 
 		mtp: mtp@24e400000 {
@@ -1393,6 +1563,36 @@
 
 		};
 
+		sep_dart: iommu@25d2c0000 {
+			compatible = "apple,t8112-dart", "apple,t8110-dart";
+			reg = <0x2 0x5d2c0000 0x0 0x4000>;
+			#iommu-cells = <1>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 282 IRQ_TYPE_LEVEL_HIGH>;
+		};
+
+		sep: sep@25e400000 {
+			compatible = "apple,sep";
+			reg = <0x2 0x5e400000 0x0 0x6C000>;
+			mboxes = <&sep_mbox>;
+			mbox-names = "mbox";
+			iommus = <&sep_dart 0>;
+			status = "disabled";
+		};
+
+		sep_mbox: mbox@25e408000 {
+			compatible = "apple,t8112-asc-mailbox", "apple,asc-mailbox-v4";
+			reg = <0x2 0x5e408000 0x0 0x4000>;
+			interrupt-parent = <&aic>;
+			interrupts = <AIC_IRQ 276 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 277 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 278 IRQ_TYPE_LEVEL_HIGH>,
+				<AIC_IRQ 279 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-names = "send-empty", "send-not-empty",
+				"recv-empty", "recv-not-empty";
+			#mbox-cells = <0>;
+		};
+
 		dispext0_dart: iommu@271304000 {
 			compatible = "apple,t8112-dart", "apple,t8110-dart";
 			reg = <0x2 0x71304000 0x0 0x4000>;
@@ -1449,13 +1649,25 @@
 			power-domains = <&ps_dispext_cpu0>;
 			resets = <&ps_dispext_cpu0>;
 			clocks = <&clk_dispext0>;
-			apple,asc-dram-mask = <0x0 0x0>;
 			apple,dcp-index = <1>;
 			status = "disabled";
+			// required bus properties for 'piodma' subdevice
+			#address-cells = <2>;
+			#size-cells = <2>;
 
-			dispext0_piodma: piodma {
+			piodma {
 				iommus = <&dispext0_dart 4>;
-				phandle = <&dispext0_piodma>;
+			};
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				port@0 {
+					reg = <0>;
+					dcpext_audio: endpoint {
+						remote-endpoint = <&dpaudio1_dcp>;
+					};
+				};
 			};
 		};
 
@@ -1494,8 +1706,9 @@
 		};
 
 		dwc3_0: usb@382280000 {
-			compatible = "apple,t8112-dwc3", "apple,dwc3", "snps,dwc3";
-			reg = <0x3 0x82280000 0x0 0x100000>;
+			compatible = "apple,t8112-dwc3", "apple,t8103-dwc3";
+			reg = <0x3 0x82280000 0x0 0xcd00>, <0x3 0x8228cd00 0x0 0x3200>;
+			reg-names = "dwc3-core", "dwc3-apple";
 			interrupt-parent = <&aic>;
 			interrupts = <AIC_IRQ 1031 IRQ_TYPE_LEVEL_HIGH>;
 			dr_mode = "otg";
@@ -1509,7 +1722,7 @@
 		};
 
 		dwc3_0_dart_0: iommu@382f00000 {
-			compatible = "apple,t8112-dart", "apple,t8110-dart";
+			compatible = "apple,t8110-dart";
 			reg = <0x3 0x82f00000 0x0 0x4000>;
 			interrupt-parent = <&aic>;
 			interrupts = <AIC_IRQ 1035 IRQ_TYPE_LEVEL_HIGH>;
@@ -1518,7 +1731,7 @@
 		};
 
 		dwc3_0_dart_1: iommu@382f80000 {
-			compatible = "apple,t8112-dart", "apple,t8110-dart";
+			compatible = "apple,t8110-dart";
 			reg = <0x3 0x82f80000 0x0 0x4000>;
 			interrupt-parent = <&aic>;
 			interrupts = <AIC_IRQ 1035 IRQ_TYPE_LEVEL_HIGH>;
@@ -1560,13 +1773,20 @@
 
 			orientation-switch;
 			mode-switch;
-			svid = <0xff01>, <0x8087>;
+			power-domains = <&ps_atc0_usb>;
+		};
+
+		atcphy0_xbar: mux@38304c000 {
+			compatible = "apple,t8112-display-crossbar", "apple,t8103-display-crossbar";
+			reg = <0x3 0x8304c000 0x0 0x4000>;
+			#mux-control-cells = <1>;
 			power-domains = <&ps_atc0_usb>;
 		};
 
 		dwc3_1: usb@502280000 {
-			compatible = "apple,t8112-dwc3", "apple,dwc3", "snps,dwc3";
-			reg = <0x5 0x02280000 0x0 0x100000>;
+			compatible = "apple,t8112-dwc3", "apple,t8103-dwc3";
+			reg = <0x5 0x02280000 0x0 0xcd00>, <0x5 0x0228cd00 0x0 0x3200>;
+			reg-names = "dwc3-core", "dwc3-apple";
 			interrupt-parent = <&aic>;
 			interrupts = <AIC_IRQ 1112 IRQ_TYPE_LEVEL_HIGH>;
 			dr_mode = "otg";
@@ -1580,7 +1800,7 @@
 		};
 
 		dwc3_1_dart_0: iommu@502f00000 {
-			compatible = "apple,t8112-dart", "apple,t8110-dart";
+			compatible = "apple,t8110-dart";
 			reg = <0x5 0x02f00000 0x0 0x4000>;
 			interrupt-parent = <&aic>;
 			interrupts = <AIC_IRQ 1116 IRQ_TYPE_LEVEL_HIGH>;
@@ -1589,7 +1809,7 @@
 		};
 
 		dwc3_1_dart_1: iommu@502f80000 {
-			compatible = "apple,t8112-dart", "apple,t8110-dart";
+			compatible = "apple,t8110-dart";
 			reg = <0x5 0x02f80000 0x0 0x4000>;
 			interrupt-parent = <&aic>;
 			interrupts = <AIC_IRQ 1116 IRQ_TYPE_LEVEL_HIGH>;
@@ -1606,6 +1826,9 @@
 				<0x5 0x02a84000 0x0 0x4000>;
 			reg-names = "core", "lpdptx", "axi2af", "usb2phy",
 				"pipehandler";
+
+			#phy-cells = <1>;
+			#reset-cells = <0>;
 
 			nvmem-cells = <&atcphy1_aus_cmn_shm_vreg_trim>,
 				<&atcphy1_auspll_rodco_encap>,
@@ -1626,12 +1849,15 @@
 				"cio3pll_dll_start_capcode",
 				"cio3pll_dtc_vreg_adjust";
 
-			#phy-cells = <1>;
-			#reset-cells = <0>;
-
 			orientation-switch;
 			mode-switch;
-			svid = <0xff01>, <0x8087>;
+			power-domains = <&ps_atc1_usb>;
+		};
+
+		atcphy1_xbar: mux@50304c000 {
+			compatible = "apple,t8112-display-crossbar", "apple,t8103-display-crossbar";
+			reg = <0x5 0x0304c000 0x0 0x4000>;
+			#mux-control-cells = <1>;
 			power-domains = <&ps_atc1_usb>;
 		};
 
@@ -1711,6 +1937,8 @@
 			power-domains = <&ps_apcie_gp>;
 			pinctrl-0 = <&pcie_pins>;
 			pinctrl-names = "default";
+
+			dma-coherent;
 
 			port00: pci@0,0 {
 				device_type = "pci";


### PR DESCRIPTION
This synchronizes the device trees with those that are in the 6.18 kernel. 
Ideally, it will fix the issue of USB not working for users post update to 6.18 kernels.
These now match the current state of the device trees on the asahi branch of the Asahi Linux github repository.

Please let me know if I have to add a sign off onto the commit.
