### PR TITLE
power: domain: Add Apple PMP reporting driver

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -142,6 +142,7 @@ F:	drivers/pci/pcie_apple.c
 F:	drivers/phy/phy-apple-atc.c
 F:	drivers/pinctrl/pinctrl-apple.c
 F:	drivers/power/domain/apple-pmgr.c
+F:	drivers/power/domain/apple-pmp-report.c
 F:	drivers/spi/apple_spi.c
 F:	drivers/usb/host/xhci-pci-asmedia.c
 F:	drivers/watchdog/apple_wdt.c

--- a/drivers/power/domain/Kconfig
+++ b/drivers/power/domain/Kconfig
@@ -18,6 +18,19 @@ config APPLE_PMGR_POWER_DOMAIN
 	  This driver is needed to power on parts of the SoC that have
 	  not been powered on by previous boot stages.
 
+config APPLE_PMP_REPORT_POWER_DOMAIN
+	bool "Enable the Apple PMP reporting power domain driver"
+	depends on POWER_DOMAIN
+	default y if ARCH_APPLE
+	help
+	  Enable support for reporting power states to the Apple Power
+	  Management Processor (PMP).
+
+	  This is a dummy driver since the PMP is entirely optional and
+	  enabling is not necessary during boot. However, it allows for
+	  devices bound to a PMGR domain through a PMP reporting domain to be
+	  powered on.
+
 config AGILEX5_PMGR_POWER_DOMAIN
 	bool "Enable the Agilex5 PMGR power domain driver"
 	depends on SPL_POWER_DOMAIN && TARGET_SOCFPGA_SOC64

--- a/drivers/power/domain/Makefile
+++ b/drivers/power/domain/Makefile
@@ -5,6 +5,7 @@
 
 obj-$(CONFIG_$(PHASE_)POWER_DOMAIN) += power-domain-uclass.o
 obj-$(CONFIG_APPLE_PMGR_POWER_DOMAIN) += apple-pmgr.o
+obj-$(CONFIG_APPLE_PMP_REPORT_POWER_DOMAIN) += apple-pmp-report.o
 obj-$(CONFIG_AGILEX5_PMGR_POWER_DOMAIN) += altr-pmgr-agilex5.o
 obj-$(CONFIG_BCM6328_POWER_DOMAIN) += bcm6328-power-domain.o
 obj-$(CONFIG_IMX8_POWER_DOMAIN) += imx8-power-domain-legacy.o imx8-power-domain.o

--- a/drivers/power/domain/apple-pmp-report.c
+++ b/drivers/power/domain/apple-pmp-report.c
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Copyright (C) 2026 Yureka <yureka@cyberchaos.dev>
+ */
+
+#include <dm.h>
+#include <power-domain-uclass.h>
+
+static const struct udevice_id apple_pmp_report_ids[] = {
+	{ .compatible = "apple,t6000-pmp-v2-report" },
+	{ .compatible = "apple,t6020-pmp-v2-report" },
+	{ .compatible = "apple,t6030-pmp-v2-report" },
+	{ .compatible = "apple,t8112-pmp-v2-report" },
+	{ /* sentinel */ }
+};
+
+U_BOOT_DRIVER(apple_pmp_report) = {
+	.name = "apple_pmp_report",
+	.id = UCLASS_NOP,
+	.of_match = apple_pmp_report_ids,
+	.bind = dm_scan_fdt_dev,
+};
+
+static int apple_pmp_report_entry_of_xlate(struct power_domain *power_domain,
+					   struct ofnode_phandle_args *args)
+{
+	return 0;
+}
+
+static const struct udevice_id apple_pmp_report_entry_ids[] = {
+	{ .compatible = "apple,t6000-pmp-v2-report-entry" },
+	{ .compatible = "apple-pmp-report-entry" },
+	{ /* sentinel */ }
+};
+
+struct power_domain_ops apple_pmp_report_entry_ops = {
+	.of_xlate = apple_pmp_report_entry_of_xlate,
+};
+
+U_BOOT_DRIVER(apple_pmp_report_entry) = {
+	.name = "apple_pmp_report_entry",
+	.id = UCLASS_POWER_DOMAIN,
+	.of_match = apple_pmp_report_entry_ids,
+	.ops = &apple_pmp_report_entry_ops,
+};


### PR DESCRIPTION
(Also submitted to upstream via the mailing list.)

The Power Management Processor (PMP) is a coprocessor found on certain Apple SoCs.

This is a dummy driver which allows for devices bound to a PMGR domain through a PMP reporting domain to be powered on.
Powering on the PMP itself is not necessary during boot.

Tested on M3 Max (T6034) with the nvme device tree node using one of the PMP reporting power domains.